### PR TITLE
Added support of Python 3.13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.8", "3.10", "3.12"]
+        python-version: ["3.8", "3.10", "3.12", "3.13"]
     services:
       mariadb:
         image: mariadb:latest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pbr>=1.10.0,<=5.8.1  # Apache-2.0
 six>=1.13.0,<=1.16.0  # MIT
-WebOb>=1.6.1,<1.8.7  # MIT
+WebOb>=1.8.9,<1.9.0  # MIT
 requests>=2.11.1,<=2.32.3  # Apache-2.0
 mysql-connector-python==8.4.0  # GPLv2
 oslo.config>=3.22.0,<8  # Apache-2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ classifier =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
 
 [entry_points]
 console_scripts =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist = pep8
-          begin,py3{8,10,12},end
+          begin,py3{8,10,12,13},end
           py27-functional,py3{6,8}-functional
 minversion = 2.0
 skipsdist = true


### PR DESCRIPTION
Bumped up version WebOb to 1.8.9 for Python 3.13 support. The old latest possible version of WebOb(1.8.6) used `cgi` module. It  was removed [from 3.13 ](https://peps.python.org/pep-0594/#deprecated-modules)