### PR TITLE
CI: ensure python version from version matrix to be used

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,12 +13,11 @@ jobs:
         python-version: ["3.12"]
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install tox
-        run: sudo apt update && sudo apt install --yes tox
+        run: pip install tox
       - name: Flake8
         run: |
           tox -e pep8
@@ -41,12 +40,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install tox
-        run: sudo apt update && sudo apt install --yes tox
+        run: pip install tox
       - name: Unit tests
         run: |
           tox -e ${{ matrix.python-version }}


### PR DESCRIPTION
Before: py3.12 was used:
```
Run tox -e 3.13
...
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-7.0.1, pluggy-1.5.0
```

After:
```
Run tox -e 3.13
...
============================= test session starts ==============================
platform linux -- Python 3.13.1, pytest-7.0.1, pluggy-1.5.0
```