### PR TITLE
Bumb urllib3 to >=1.26.19,<2.0.0

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
 coverage>=3.6,<6  # Apache-2.0
 flake8>=6.1.0  # MIT License (MIT)
 mock>=1.0.1,<3.0.5  # BSD
-urllib3<=1.26.8  # MIT
+urllib3>=1.26.19,<2.0.0  # MIT
 pytest==7.0.1  # MIT License (MIT)
 pytest-timer==0.0.11 # MIT License (MIT)


### PR DESCRIPTION
fixes:  [#7](https://github.com/infraguys/restalchemy/security/dependabot/7) [#8](https://github.com/infraguys/restalchemy/security/dependabot/8) [#9](https://github.com/infraguys/restalchemy/security/dependabot/9)