### PR TITLE
Add PostgreSQL support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,9 +34,23 @@ jobs:
           - 3306:3306
         env:
           MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: 1
-          MARIADB_DATABASE: radatabase
-          MARIADB_USERf: root
+          MARIADB_DATABASE: ra_database
+          MARIADB_USER: root
+          MYSQL_ROOT_PASSWORD: test_password
         options: --health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=10s --health-timeout=5s --health-retries=3
+      postgresql:
+        image: postgres:latest
+        # Provide the password for postgres
+        env:
+          POSTGRES_DB: ra_database
+          POSTGRES_HOST_AUTH_METHOD: trust
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: test_password
+        # Set health checks to wait until postgres has started
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+        ports:
+          # Maps tcp port 5432 on service container to the host
+          - 5432:5432
 
     steps:
       - uses: actions/checkout@v3
@@ -48,6 +62,13 @@ jobs:
       - name: Unit tests
         run: |
           tox -e ${{ matrix.python-version }}
-      - name: Functional tests
+      - name: Functional MySQL tests
+        env:
+          DATABASE_URI: "mysql://root:test_password@localhost:3306/ra_database"
+        run: |
+          tox -e ${{ matrix.python-version }}-functional
+      - name: Functional PostgreSQL tests
+        env:
+          DATABASE_URI: "postgresql://postgres:test_password@localhost:5432/ra_database"
         run: |
           tox -e ${{ matrix.python-version }}-functional

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ __pycache__/
 
 # IDE
 .idea/
+.vscode/
 
 # Distribution / packaging
 .Python

--- a/examples/dm_pg_storage.py
+++ b/examples/dm_pg_storage.py
@@ -1,0 +1,122 @@
+# Copyright 2016 Eugene Frolov <eugene@frolov.net.ru>
+#
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import six
+
+from restalchemy.dm import filters
+from restalchemy.dm import models
+from restalchemy.dm import properties
+from restalchemy.dm import relationships
+from restalchemy.dm import types
+from restalchemy.storage.sql import engines
+from restalchemy.storage.sql import orm
+
+
+# CREATE TABLE foos (
+#      uuid CHAR(36) PRIMARY KEY,
+#      foo_field1 INT NOT NULL ,
+#      foo_field2 VARCHAR(255) NOT NULL
+# );
+class FooModel(models.ModelWithUUID, orm.SQLStorableMixin):
+    __tablename__ = "foos"
+    foo_field1 = properties.property(types.Integer(), required=True)
+    foo_field2 = properties.property(types.String(), default="foo_str")
+
+
+# CREATE TABLE bars (
+#     uuid CHAR(36) NOT NULL PRIMARY KEY,
+#     bar_field1 VARCHAR(10) NOT NULL,
+#     foo CHAR(36) NOT NULL,
+#     FOREIGN KEY (foo) REFERENCES foos(uuid) ON DELETE RESTRICT ON UPDATE
+#       RESTRICT
+# );
+#
+# CREATE INDEX rlfoo ON bars(foo);
+class BarModel(models.ModelWithUUID, orm.SQLStorableMixin):
+    __tablename__ = "bars"
+    bar_field1 = properties.property(types.String(min_length=1, max_length=10))
+    foo = relationships.relationship(FooModel)
+
+
+engines.engine_factory.configure_factory(
+    db_url="postgresql://posgres:password@127.0.0.1:5432/ra_tests"
+)
+
+# Create new foo object and store it
+foo1 = FooModel(foo_field1=10)
+foo1.save()
+
+bar1 = BarModel(bar_field1="test", foo=foo1)
+bar1.save()
+
+six.print_(list(BarModel.objects.get_all()))
+six.print_(BarModel.objects.get_one(filters={"uuid": bar1.get_id()}))
+six.print_(list(BarModel.objects.get_all(filters={"foo": foo1})))
+six.print_(bar1.as_plain_dict())
+
+bar1.delete()
+
+foo2 = FooModel(foo_field1=11, foo_field2="some text")
+foo2.save()
+
+foos = list(FooModel.objects.get_all())
+six.print_(foos)
+
+six.print_(FooModel.objects.get_one(filters={"foo_field1": filters.EQ(10)}))
+
+# Modify foo_field2 and update it in storage
+foo2.foo_field2 = "xxx2 asdad asdasd"
+foo2.save()
+
+# Delete foo object from storage
+for foo in foos:
+    foo.delete()
+
+six.print_("foo_field1 is greater than 5")
+for num in range(10):
+    foo = FooModel(foo_field1=num)
+    foo.save()
+
+six.print_(
+    list(FooModel.objects.get_all(filters={"foo_field1": filters.GT(5)}))
+)
+
+six.print_("foo_field1 in equal 5 or 6")
+six.print_(
+    FooModel.objects.get_all(filters={"foo_field1": filters.In([5, 6])})
+)
+six.print_(
+    FooModel.objects.get_all(filters={"foo_field1": filters.NotIn([1, 2])})
+)
+
+for model in FooModel.objects.get_all():
+    model.delete()
+
+# Complex filters
+# WHERE ((`foo_field1` = 1 AND `foo_field2` = 2) OR (`foo_field2` = 3))
+# filter_list = filters.OR(
+#     filters.AND(
+#         {
+#             "foo_field1": filters.EQ(1),
+#             "foo_field2": filters.EQ("2"),
+#         }
+#     ),
+#     filters.AND({"foo_field2": filters.EQ("3")}),
+# )
+
+# FooModel(foo_field1=1, foo_field2="2").save()
+
+# six.print_(FooModel.objects.get_one(filters=filter_list))

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ mysql-connector-python==8.4.0  # GPLv2
 oslo.config>=3.22.0,<8  # Apache-2.0
 PyYAML>=6.0  # MIT
 netaddr>=0.7.18  # BSD
+psycopg[binary,pool]>=3.2.4,<4.0.0  # GNU Lesser General Public License v3 (LGPLv3)

--- a/restalchemy/storage/sql/dialect/base.py
+++ b/restalchemy/storage/sql/dialect/base.py
@@ -18,58 +18,1095 @@ import abc
 
 import six
 
+from restalchemy.storage.sql.dialect.query_builder import q
+from restalchemy.storage.sql import filters as sql_filters
+
 
 @six.add_metaclass(abc.ABCMeta)
 class AbstractProcessResult(object):
 
-    def __init__(self, result):
+    def __init__(self, result, session):
         self._result = result
+        self._session = session
+
+    def get_count(self):
+        """
+        Retrieves the number of rows affected by the query.
+
+        :return: The number of rows affected by the executed SQL statement.
+        :rtype: int
+        """
+
+        return self._result.rowcount
+
+    @property
+    def rows(self):
+        """
+        Retrieves all rows from the executed SQL statement.
+
+        :return: All rows from the executed SQL statement.
+        :rtype: list
+        """
+        return self.get_rows()
 
     @abc.abstractmethod
-    def get_count(self):
+    def fetchall(self):
+        """
+        Retrieves all rows from the executed SQL statement.
+
+        :return: All rows from the executed SQL statement.
+        """
         raise NotImplementedError()
+
+    @abc.abstractmethod
+    def get_rows(self):
+        """
+        Retrieves all rows from the executed SQL statement.
+
+        :return: All rows from the executed SQL statement.
+        :rtype: list
+        """
+        raise NotImplementedError()
+
+
+class BaseProcessResult(AbstractProcessResult):
+
+    def __init__(self, result, session):
+        """
+        Initializes the BaseProcessResult object.
+
+        :param result: The result of the executed SQL statement.
+        :param session: The session object used for the execution
+            of the SQL statement.
+        """
+        super(BaseProcessResult, self).__init__(result, session)
+        self._rows = None
+
+    def fetchall(self):
+        """
+        Retrieves all rows from the executed SQL statement.
+
+        :return: All rows from the executed SQL statement.
+        """
+        for row in self._result:
+            yield row
+
+    def get_rows(self):
+        """
+        Retrieves all rows from the executed SQL statement and caches them.
+
+        If the rows have not been previously retrieved, it fetches all rows
+        from the result and stores them in the `_rows` attribute. Otherwise,
+        it returns the cached rows.
+
+        :return: All rows from the executed SQL statement.
+        :rtype: list
+        """
+
+        if self._rows is None:
+            self._rows = self._result.fetchall()
+        return self._rows
+
+
+class BaseOrmProcessResult(BaseProcessResult):
+
+    def __init__(self, result, query, session):
+        """
+        Initializes the BaseOrmProcessResult object.
+
+        :param result: The result of the executed ORM query
+        :param query: The ORM query object used for the execution
+            of the SQL statement
+        :param session: The session object used for the execution
+            of the SQL statement
+        """
+        super(BaseOrmProcessResult, self).__init__(
+            result=result,
+            session=session,
+        )
+        self._query = query
+        self._rows = None
+
+    def fetchall(self):
+        """
+        Retrieves all rows from the executed ORM query.
+
+        :return: All rows from the executed ORM query, parsed into objects.
+        """
+        for row in self._result:
+            yield self._query.parse_row(row)
+
+    def get_rows(self):
+        """
+        Retrieves all rows from the executed ORM query, parsing them into
+        objects and caching the result for future access.
+
+        If the rows have not been previously retrieved, it fetches all rows
+        from the result, parses them using the query's result parser, and
+        stores them in the `_rows` attribute. Otherwise, it returns the cached
+        rows.
+
+        :return: All rows from the executed ORM query, parsed into objects.
+        :rtype: list
+        """
+
+        if self._rows is None:
+            self._rows = self._query.parse_results(self._result.fetchall())
+        return self._rows
 
 
 @six.add_metaclass(abc.ABCMeta)
 class AbstractDialectCommand(object):
 
-    def __init__(self, table, data):
+    def __init__(self, table, data, session):
+        """
+        Initializes the AbstractDialectCommand with the given table, data,
+        and session.
+
+        :param table: The table associated with the command.
+        :param data: The data to be used in the command.
+        :param session: The session to be used for executing the command.
+        """
+
         self._table = table
         self._data = data
+        self._session = session
 
     @abc.abstractmethod
     def get_values(self):
+        """
+        Retrieves the values to be used in the SQL command execution.
+
+        This method should be implemented by subclasses to provide the logic
+        for extracting or constructing the values required for the SQL
+        statement. The values should be returned in a format compatible with
+        the SQL execution context.
+
+        :return: A collection of values to be used in the SQL command.
+        """
+
         raise NotImplementedError()
 
     @abc.abstractmethod
     def get_statement(self):
+        """
+        Retrieves the SQL statement to be used in the command execution.
+
+        This method should be implemented by subclasses to provide the logic
+        for constructing the SQL statement required for the command. The
+        statement should be returned as a string, with placeholders for the
+        values to be inserted.
+
+        :return: The SQL statement to be used in the command execution.
+        :rtype: str
+        """
         raise NotImplementedError()
 
-    def execute(self, session):
+    def execute(self):
+        """
+        Executes the SQL command using the values and statement provided by
+        the abstract methods.
+
+        :return: A ProcessResult object containing the result of the SQL
+            command.
+        """
         values = self.get_values()
         statement = self.get_statement()
-        return session.execute(statement, values)
+        return BaseProcessResult(
+            result=self._session.execute(statement, values),
+            session=self._session,
+        )
+
+
+class BaseInsertCommand(AbstractDialectCommand):
+
+    EXPRESSION = "INSERT INTO `%s` (%s) VALUES (%s)"
+
+    def get_values(self):
+        """
+        Retrieves the values to be inserted into the SQL command.
+
+        This method iterates over the column names of the table and collects
+        the corresponding data values into a tuple. These values are then
+        used as the data to be inserted into the SQL statement.
+
+        :return: A tuple of values corresponding to the column names of the
+            table.
+        :rtype: tuple
+        """
+
+        values = tuple()
+        for column_name in self._table.get_column_names(self._session):
+            values += (self._data[column_name],)
+        return values
+
+    def get_statement(self):
+        """
+        Retrieves the SQL statement to be used in the command execution.
+
+        This method constructs the SQL statement to be used in the command
+        execution by inserting the table name and column names into the
+        EXPRESSION template string. The column names are escaped according to
+        the dialect's escaping rules, and the placeholders for the values are
+        created by repeating the string "%s" for each column.
+
+        :return: The SQL statement to be used in the command execution.
+        :rtype: str
+        """
+        column_names = self._table.get_escaped_column_names(self._session)
+        return self.EXPRESSION % (
+            self._table.name,
+            ", ".join(column_names),
+            ", ".join(["%s"] * len(column_names)),
+        )
+
+
+class BaseUpdateCommand(AbstractDialectCommand):
+
+    EXPRESSION = "UPDATE `%s` SET %s WHERE %s"
+
+    def __init__(self, table, ids, data, session):
+        """
+        Initializes the BaseUpdateCommand with the given table, ids, data,
+        and session.
+
+        :param table: The table associated with the command.
+        :param ids: The ids to be updated.
+        :param data: The data to be used in the command.
+        :param session: The session to be used for executing the command.
+        """
+        super().__init__(table, data, session=session)
+        self._ids = ids
+
+    def get_values(self):
+        """
+        Retrieves the values to be updated in the SQL command.
+
+        This method iterates over the column names of the table (excluding the
+        primary key) and collects the corresponding data values into a tuple.
+        Additionally, it collects the primary key values from the `_ids` attr
+        into the same tuple. These values are then used as the data to be
+        updated in the SQL statement.
+
+        :return: A tuple of values corresponding to the column names of the
+            table.
+        :rtype: tuple
+        """
+        values = tuple()
+        column_names = self._table.get_column_names(
+            self._session,
+            with_pk=False,
+        )
+        pk_names = self._table.get_pk_names(session=self._session)
+        for column_name in column_names:
+            values += (self._data[column_name],)
+        for column_name in pk_names:
+            values += (self._ids[column_name],)
+        return values
+
+    def get_statement(self):
+        """
+        Retrieves the SQL statement to be used in the command execution.
+
+        This method constructs the SQL statement to be used in the command
+        execution by inserting the table name, column names, and primary key
+        names into the EXPRESSION template string. The column names are escaped
+        according to the dialect's escaping rules, and the placeholders for the
+        values are created by repeating the string "%s" for each column.
+
+        :return: The SQL statement to be used in the command execution.
+        :rtype: str
+        """
+        column_names = self._table.get_escaped_column_names(
+            session=self._session,
+            with_pk=False,
+        )
+        pk_names = self._table.get_escaped_pk_names(session=self._session)
+        return self.EXPRESSION % (
+            self._table.name,
+            ", ".join([f"{name} = %s" for name in column_names]),
+            " AND ".join([f"{name} = %s" for name in pk_names]),
+        )
+
+
+class BaseDeleteCommand(AbstractDialectCommand):
+
+    EXPRESSION = "DELETE FROM `%s` WHERE %s"
+
+    def __init__(self, table, ids, session):
+        """
+        Initializes the BaseDeleteCommand with the given table, ids, and
+        session.
+
+        :param table: The table associated with the command.
+        :param ids: The ids to be used for deleting the rows.
+        :param session: The session to be used for executing the command.
+        """
+        super().__init__(table=table, data={}, session=session)
+        self._ids = ids
+
+    def get_values(self):
+        """
+        Retrieves the values to be used in the SQL command execution.
+
+        This method iterates over the primary key column names of the table
+        and collects the corresponding data values into a tuple. These
+        values are then used as the data to be deleted in the SQL statement.
+
+        :return: A tuple of values corresponding to the primary key column
+            names of the table.
+        :rtype: tuple
+        """
+        values = tuple()
+        pk_names = self._table.get_pk_names(session=self._session)
+        for column_name in pk_names:
+            values += (self._ids[column_name],)
+        return values
+
+    def get_statement(self):
+        """
+        Retrieves the SQL statement to be used in the command execution.
+
+        This method constructs the SQL statement to be used in the command
+        execution by inserting the table name and primary key column names
+        into the EXPRESSION template string.
+
+        :return: The SQL statement to be used in the command execution.
+        :rtype: str
+        """
+        pk_names = self._table.get_escaped_pk_names(session=self._session)
+        return self.EXPRESSION % (
+            self._table.name,
+            " AND ".join([f"{name} = %s" for name in pk_names]),
+        )
+
+
+class BaseBatchDelete(AbstractDialectCommand):
+
+    EXPRESSION_IN = "DELETE FROM `%s` WHERE %s in %s"
+    EXPRESSION_FILTER = "DELETE FROM `%s` WHERE %s"
+
+    def __init__(self, table, snapshot, session):
+        """
+        Initializes the BaseBatchDelete with the given table, snapshot, and
+        session.
+
+        :param table: The table associated with the command.
+        :param snapshot: The snapshot containing the rows to be deleted.
+        :param session: The session to be used for executing the command.
+        """
+        super().__init__(
+            table=table,
+            data={},
+            session=session,
+        )
+        self._snapshot = snapshot
+        self._pk_keys = self._table.get_escaped_pk_names(session=session)
+        keys_count = len(self._pk_keys)
+        if keys_count == 1:
+            self._is_multiple_primary_key = False
+        elif keys_count > 1:
+            self._is_multiple_primary_key = True
+        else:
+            raise ValueError(
+                f"The model with table {table!r} has 0 primary keys"
+            )
+
+    def _get_values(self):
+        """
+        Retrieves the values to be used in the SQL command execution.
+
+        This method iterates over the snapshot rows and collects the values
+        corresponding to the primary key column names of the table into a
+        list. These values are then used as the data to be deleted in the SQL
+        statement.
+
+        :return: A list of values corresponding to the primary key column
+            names of the table.
+        :rtype: list
+        """
+        values = []
+        for snapshot in self._snapshot:
+            for key in self._table.get_pk_names(session=self._session):
+                values.append(snapshot[key])
+        return values
+
+    def _get_multiple_primary_key_values(self):
+        """
+        Retrieves the values to be used in the SQL command execution when
+        multiple primary keys are declared for the table.
+
+        :return: A list of values corresponding to the primary key column
+            names of the table.
+        :rtype: list
+        """
+        return self._get_values()
+
+    def _get_single_primary_key_values(self):
+        """
+        Retrieves the primary key values for tables with a single primary key.
+
+        This method wraps the result of `_get_multiple_primary_key_values` in a
+        list to optimize the `in` operation for SQL command execution.
+
+        :return: A list containing the primary key values.
+        :rtype: list
+        """
+        # NOTE(efrolov): Wrap to list for `in` optimization
+        return [self._get_multiple_primary_key_values()]
+
+    def get_values(self):
+        """
+        Retrieves the values to be used in the SQL command execution.
+
+        Depending on the presence of multiple primary keys declared for the
+        table,this method returns either a list of values corresponding to
+        the primary key column names of the table or a list containing the
+        primary key values for tables with a single primary key.
+
+        :return: List of values to be used in the SQL command execution.
+        :rtype: list
+        """
+        return (
+            self._get_multiple_primary_key_values()
+            if self._is_multiple_primary_key
+            else self._get_single_primary_key_values()
+        )
+
+    def _get_single_primary_key_statement(self):
+        """
+        Retrieves the SQL statement to be used in the command execution
+        when a single primary key is declared for the table.
+
+        This method constructs the SQL statement to be used in the command
+        execution by inserting the table name and primary key column name
+        into the EXPRESSION_IN template string.
+
+        :return: The SQL statement to be used in the command execution.
+        :rtype: str
+        """
+        return self.EXPRESSION_IN % (
+            self._table.name,
+            self._pk_keys[0],
+            "%s",
+        )
+
+    def _get_multiple_primary_key_statement(self):
+        """
+        Retrieves the SQL statement to be used in the command execution
+        when multiple primary keys are declared for the table.
+
+        This method constructs the SQL statement to be used in the command
+        execution by inserting the table name and primary key column names
+        into the EXPRESSION_FILTER template string. The `where_condition` is
+        constructed by joining the condition for each primary key column
+        with the `OR` operator.
+
+        :return: The SQL statement to be used in the command execution.
+        :rtype: str
+        """
+        where_part = " AND ".join([f"{key} = %s" for key in self._pk_keys])
+        where_condition = " OR ".join(
+            [where_part for _ in range(len(self._snapshot))]
+        )
+        return self.EXPRESSION_FILTER % (
+            self._table.name,
+            where_condition,
+        )
+
+    def get_statement(self):
+        """
+        Retrieves the SQL statement to be used in the command execution.
+
+        This method constructs the SQL statement based on whether the table
+        has multiple primary keys or a single primary key. It selects the
+        appropriate expression template and formats it with the table name
+        and primary key conditions.
+
+        :return: The SQL statement to be used in the command execution.
+        :rtype: str
+        """
+
+        return (
+            self._get_multiple_primary_key_statement()
+            if self._is_multiple_primary_key
+            else self._get_single_primary_key_statement()
+        )
+
+
+class BaseBasicSelectCommand(AbstractDialectCommand):
+
+    EXPRESSION = "SELECT %s FROM `%s`"
+
+    def __init__(
+        self,
+        table,
+        session,
+        limit=None,
+        order_by=None,
+        locked=False,
+    ):
+        """
+        Initializes the BaseBasicSelectCommand with the given parameters.
+
+        :param table: The table from which data is to be selected.
+        :param session: The session to be used for executing the command.
+        :param limit: The maximum number of rows to return. Optional.
+        :type limit: int, optional
+        :param order_by: A dictionary specifying the columns to order by and
+            their sort types. Optional.
+        :param locked: Whether to lock the selected rows for update. Defaults
+            to False.
+        :type locked: bool
+        """
+
+        super().__init__(table=table, data={}, session=session)
+        self._limit = limit
+        self._order_by = order_by
+        self._locked = locked
+
+    def construct_limit(self):
+        """
+        Constructs the LIMIT clause for the SQL statement based on the given
+        limit.
+
+        :return: The LIMIT clause for the SQL statement.
+        :rtype: str
+        """
+        if self._limit:
+            return " LIMIT " + str(self._limit)
+        return ""
+
+    def construct_locked(self):
+        """
+        Constructs the FOR UPDATE clause for the SQL statement based on the
+        given locked status.
+
+        :return: The FOR UPDATE clause for the SQL statement.
+        :rtype: str
+        """
+        if self._locked:
+            return " FOR UPDATE"
+        return ""
+
+    def construct_order_by(self):
+        """
+        Constructs the ORDER BY clause for the SQL statement based on the
+        given order_by.
+
+        :return: The ORDER BY clause for the SQL statement.
+        :rtype: str
+        """
+
+        if self._order_by:
+            res = []
+            for name, sorttype in self._order_by.items():
+                sorttype = sorttype.upper()
+                if sorttype not in ["ASC", "DESC", "", None]:
+                    raise ValueError(f"Unknown order: {sorttype}.")
+                res.append(
+                    f"{self._session.engine.escape(name)} {sorttype or 'ASC'}"
+                )
+            return " ORDER BY " + ", ".join(res)
+        return ""
+
+
+class BaseSelectCommand(BaseBasicSelectCommand):
+
+    def __init__(
+        self,
+        table,
+        session,
+        filters=None,
+        limit=None,
+        order_by=None,
+        locked=False,
+    ):
+        """
+        Initializes the BaseSelectCommand with the given parameters.
+
+        :param table: The table from which data is to be selected.
+        :param session: The session to be used for executing the command.
+        :param filters: The filters to be applied to the query. Optional.
+        :param limit: The maximum number of rows to return. Optional.
+        :type limit: int, optional
+        :param order_by: A dictionary specifying the columns to order by
+            and their sort types. Optional.
+        :param locked: Whether to lock the selected rows for update. Defaults
+            to False.
+        :type locked: bool
+        """
+        super(BaseSelectCommand, self).__init__(
+            table=table,
+            session=session,
+            limit=limit,
+            order_by=order_by,
+            locked=locked,
+        )
+        self._filters = sql_filters.convert_filters(
+            model=self._table.model,
+            filters_root=filters,
+            session=session,
+        )
+
+    def get_values(self):
+        """
+        Retrieves the values to be used in the SQL command execution.
+
+        This method returns the values part of the WHERE clause of the
+        SQL statement, which is used to filter the results of the query.
+
+        :return: The values part of the WHERE clause.
+        :rtype: tuple
+        """
+
+        return self._filters.value
+
+    def construct_where(self):
+        """
+        Constructs the WHERE clause part of the SQL statement.
+
+        This method returns the WHERE clause part of the SQL statement,
+        which is used to filter the results of the query.
+
+        :return: The WHERE clause part of the SQL statement.
+        :rtype: str
+        """
+        return self._filters.construct_expression()
+
+    def get_statement(self):
+        sql = self.EXPRESSION % (
+            ", ".join(self._table.get_escaped_column_names(self._session)),
+            self._table.name,
+        )
+        filt = self.construct_where()
+
+        return (
+            (f"{sql} WHERE {filt}" if filt else sql)
+            + self.construct_order_by()
+            + self.construct_limit()
+            + self.construct_locked()
+        )
+
+
+class BaseCustomSelectCommand(BaseBasicSelectCommand):
+
+    def __init__(
+        self,
+        table,
+        where_conditions,
+        where_values,
+        session,
+        limit=None,
+        order_by=None,
+        locked=False,
+    ):
+        """
+        :param table: Table to select from
+        :type table: :class:`~restalchemy.storage.sql.tables.SQLTable`
+        :param where_conditions: Conditions for the WHERE clause in the SQL
+            statement.
+        :param where_values: Values for the WHERE clause in the SQL statement.
+        :type where_values: tuple
+        :param session: Session to use for the query
+        :type session: :class:`~restalchemy.storage.sql.sessions.SQLSession`
+        :param limit: Maximum number of records to return
+        :type limit: int
+        :param order_by: Fields to order the records by
+        :type order_by: dict
+        :param locked: Whether to lock the records using a FOR UPDATE clause
+        :type locked: bool
+        """
+        super().__init__(
+            table=table,
+            session=session,
+            limit=limit,
+            order_by=order_by,
+            locked=locked,
+        )
+        self._where_conditions = where_conditions
+        self._where_values = where_values
+
+    def get_values(self):
+        """
+        Retrieves the values to be used in the SQL command execution.
+
+        This method returns the values part of the WHERE clause of the
+        SQL statement, which is used to filter the results of the query.
+
+        :return: The values part of the WHERE clause.
+        :rtype: tuple
+        """
+        return self._where_values
+
+    def construct_where(self):
+        """
+        Constructs the WHERE clause part of the SQL statement.
+
+        This method returns the WHERE clause part of the SQL statement,
+        which is used to filter the results of the query.
+
+        :return: The WHERE clause part of the SQL statement.
+        :rtype: str
+        """
+        return self._where_conditions
+
+    def get_statement(self):
+        """
+        Retrieves the full SQL statement for the query.
+
+        :return: The full SQL statement for the query.
+        :rtype: str
+        """
+        sql = self.EXPRESSION % (
+            ", ".join(
+                self._table.get_escaped_column_names(
+                    self._session,
+                )
+            ),
+            self._table.name,
+        )
+        return (
+            sql
+            + " WHERE "
+            + self.construct_where()
+            + self.construct_order_by()
+            + self.construct_limit()
+            + self.construct_locked()
+        )
+
+
+class BaseCountCommand(BaseSelectCommand):
+
+    EXPRESSION = "SELECT COUNT(*) as count FROM `%s`"
+
+    def __init__(self, table, session, filters=None):
+        """
+        Initializes the BaseCountCommand with the provided table, session,
+        and optional filters.
+
+        :param table: The table from which to perform the count query.
+        :param session: The session used to execute the SQL command.
+        :param filters: Optional filters to apply to the count query.
+        :type filters: Any, optional
+        """
+
+        super().__init__(table=table, session=session, filters=filters)
+
+    def get_statement(self):
+        """
+        Retrieves the full SQL statement for the query.
+
+        :return: The full SQL statement for the query.
+        :rtype: str
+        """
+        sql = self.EXPRESSION % (self._table.name)
+        filt = self.construct_where()
+
+        return f"{sql} WHERE {filt}" if filt else sql
+
+
+class BaseOrmDialectCommand(AbstractDialectCommand):
+
+    def __init__(self, table, query, session):
+        """
+        Initializes the BaseOrmDialectCommand with the given table, query, and
+        session.
+
+        :param table: The table to be used in the ORM dialect command.
+        :param query: The query object that contains the SQL query to be
+            compiled.
+        :param session: The session to be used for executing the command.
+        """
+
+        super().__init__(table=table, session=session, data=None)
+        self._query = query
+
+    def get_statement(self):
+        """
+        Compiles and retrieves the SQL statement for the query.
+
+        This method utilizes the `compile` method of the query object
+        to generate the SQL statement that represents the query.
+
+        :return: The compiled SQL statement for the query.
+        :rtype: str
+        """
+
+        return self._query.compile()
+
+    def get_values(self):
+        """
+        Retrieves the values to be used in the SQL command execution.
+
+        This method should be implemented by subclasses to provide the logic
+        for extracting or constructing the values required for the SQL
+        statement. The values should be returned in a format compatible with
+        the SQL execution context.
+
+        :return: A collection of values to be used in the SQL command.
+        :rtype: iterable
+        """
+        return self._query.values()
+
+    def execute(self):
+        """
+        Executes the SQL command associated with the query.
+
+        This method compiles the query using the `get_statement` method and
+        retrieves the values required for the query execution using the
+        `get_values` method. Subsequently, it executes the SQL command using
+        the parent class's `execute` method, passing the compiled statement and
+        values to it. The result of the execution is then wrapped in a
+        `BaseOrmProcessResult` object and returned.
+
+        :return: The result of the query execution, wrapped in a
+            `BaseOrmProcessResult` object.
+        :rtype: BaseOrmProcessResult
+        """
+        return BaseOrmProcessResult(
+            result=super().execute(),
+            query=self._query,
+            session=self._session,
+        )
+
+
+class BaseSqlOrm(object):
+
+    @staticmethod
+    def select(model, session):
+        """
+        Creates a new Q object for the given model and session.
+
+        :param model: The model class for which the Q object is to be created.
+        :param session: The session to be used for executing the query.
+        :return: A new Q object instance.
+        """
+        return q.Q.select(model, session)
 
 
 @six.add_metaclass(abc.ABCMeta)
 class AbstractDialect(object):
 
-    @abc.abstractproperty
-    def insert(self, table, data):
+    @property
+    @abc.abstractmethod
+    def DIALECT_NAME(self):
+        """
+        The name of the dialect as a string.
+
+        This property must be overridden by subclasses to provide a valid
+        dialect name.
+
+        :return: The name of the dialect as a string.
+        :rtype: str
+        """
         raise NotImplementedError()
 
-    @abc.abstractproperty
-    def update(self, table, ids, data):
+    def __init__(self):
+        """
+        Initializes the AbstractDialect instance.
+
+        This constructor sets up the base SQL ORM for the dialect by
+        creating an instance of BaseSqlOrm.
+
+        """
+
+        super(AbstractDialect, self).__init__()
+        self._orm = BaseSqlOrm()
+
+    @property
+    def orm(self):
+        """
+        Retrieves the BaseSqlOrm instance associated with the dialect.
+
+        This property returns the BaseSqlOrm instance that is used by the
+        dialect for ORM operations.
+
+        :return: The BaseSqlOrm instance associated with the dialect.
+        :rtype: BaseSqlOrm
+        """
+        return self._orm
+
+    @property
+    def name(self):
+        """
+        Retrieves the name of the dialect as a string.
+
+        This property returns the string value of the DIALECT_NAME property of
+        the dialect.
+
+        :return: The name of the dialect as a string.
+        :rtype: str
+        """
+        return self.DIALECT_NAME
+
+    @abc.abstractmethod
+    def insert(self, table, data, session):
+        """
+        Inserts data into the specified table within the session context.
+
+        This method should be implemented by subclasses to provide the logic
+        for inserting the provided data into the given table using the
+        specified session. The method should construct and execute an SQL
+        insert command appropriate for the dialect.
+
+        :param table: The table into which data is to be inserted.
+        :param data: The data to be inserted into the table.
+        :param session: The session to be used for executing the insert
+            command.
+        :raises NotImplementedError: If the method is not implemented by a
+            subclass.
+        """
+
         raise NotImplementedError()
 
-    @abc.abstractproperty
-    def delete(self, table, ids):
+    @abc.abstractmethod
+    def update(self, table, ids, data, session):
+        """
+        Updates existing records in the specified table with the provided data
+        within the session context.
+
+        This method should be implemented by subclasses to provide the logic
+        for updating existing records in the given table using the specified
+        session. The method should construct and execute an SQL update command
+        appropriate for the dialect.
+
+        :param table: The table to be updated.
+        :param ids: The IDs of the records to be updated.
+        :type ids: list
+        :param data: The data to be used for updating the records.
+        :param session: The session to be used for executing the update
+            command.
+        :raises NotImplementedError: If the method is not implemented by a
+            subclass.
+        """
         raise NotImplementedError()
 
-    @abc.abstractproperty
-    def select(self, table, filters, limit=None, order_by=None, locked=False):
+    @abc.abstractmethod
+    def delete(self, table, ids, session):
+        """
+        Deletes records from the specified table based on the provided IDs
+        within the session context.
+
+        This method should be implemented by subclasses to provide the logic
+        for deleting records from the given table using the specified session.
+        The method should construct and execute an SQL delete command
+        appropriate for the dialect.
+
+        :param table: The table from which records are to be deleted.
+        :param ids: The IDs of the records to be deleted.
+        :param session: The session to be used for executing the delete
+            command.
+        :raises NotImplementedError: If the method is not implemented by a
+            subclass.
+        """
+
         raise NotImplementedError()
 
-    @abc.abstractproperty
-    def count(self, table, filters):
+    @abc.abstractmethod
+    def select(
+        self,
+        table,
+        filters,
+        session,
+        limit=None,
+        order_by=None,
+        locked=False,
+    ):
+        """
+        Retrieves records from the specified table based on the provided
+        filters and ordering criteria, with optional limit and locking
+        constraints, within the session context.
+
+        This method should be implemented by subclasses to provide the logic
+        for selecting records from the given table using the specified
+        session. The method should construct and execute an SQL select command
+        appropriate for the dialect.
+
+        :param table: The table from which records are to be retrieved.
+        :param filters: The filters to be used for selecting the records.
+        :param session: The session to be used for executing the select
+            command.
+        :param limit: The maximum number of records to be retrieved.
+        :type limit: int
+        :param order_by: The ordering criteria to be used for selecting the
+            records.
+        :param locked: Whether or not to lock the records for this session.
+        :type locked: bool
+        :raises NotImplementedError: If the method is not implemented by a
+            subclass.
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def count(self, table, filters, session):
+        """
+        Retrieves the number of records in the specified table that match the
+        given filters within the session context.
+
+        This method should be implemented by subclasses to provide the logic
+        for counting the records from the given table using the specified
+        session. The method should construct and execute an SQL count command
+        appropriate for the dialect.
+
+        :param table: The table from which records are to be counted.
+        :param filters: The filters to be used for counting the records.
+        :param session: The session to be used for executing the count command.
+        :raises NotImplementedError: If the method is not implemented by a
+            subclass.
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def orm_command(self, table, query, session):
+        """
+        Creates a new ORM command for the given table, query, and session.
+
+        This method should be implemented by subclasses to provide the logic
+        for creating an ORM command that is appropriate for the dialect.
+
+        :param table: The table to be used in the ORM dialect command.
+        :param query: The query object that contains the SQL query to be
+            compiled.
+        :param session: The session to be used for executing the command.
+        :raises NotImplementedError: If the method is not implemented by a
+            subclass.
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def custom_select(
+        self,
+        table,
+        session,
+        where_conditions,
+        where_values,
+        limit=None,
+        order_by=None,
+        locked=False,
+    ):
+        """
+        Constructs and executes a custom SQL select command for the specified
+        table, using the given session and where conditions.
+
+        This method should be implemented by subclasses to provide the logic
+        for selecting records based on custom where conditions and values, with
+        optional limit, order by, and locking constraints.
+
+        :param table: The table from which records are to be selected.
+        :param session: The session to be used for executing the select
+            command.
+        :param where_conditions: The conditions for the WHERE clause in the SQL
+            statement.
+        :param where_values: The values for the WHERE clause in the SQL
+            statement.
+        :param limit: The maximum number of records to be retrieved.
+        :type limit: int, optional
+        :param order_by: The ordering criteria for the selected records.
+        :param locked: Whether or not to lock the selected records for update.
+        :type locked: bool
+        :raises NotImplementedError: If the method is not implemented by a
+            subclass.
+        """
+
         raise NotImplementedError()

--- a/restalchemy/storage/sql/dialect/pgsql.py
+++ b/restalchemy/storage/sql/dialect/pgsql.py
@@ -1,0 +1,398 @@
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+#
+# Copyright 2016 Eugene Frolov <eugene@frolov.net.ru>
+#
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from __future__ import absolute_import  # noqa
+
+from functools import wraps
+
+from psycopg import errors
+
+from restalchemy.storage.sql.dialect import base
+from restalchemy.storage.sql.dialect import exceptions as exc
+
+
+def handle_database_errors(func):
+    """
+    A decorator to handle PostgreSQL database errors.
+
+    This decorator catches specific database errors from the
+    `psycopg` library and raises them as :class:`.DeadLock` or
+    :class:`.Conflict` exceptions when appropriate.
+
+    :param func: The function to be wrapped.
+    :type func: callable
+    :return: A function that wraps `func` and handles database errors.
+    :rtype: callable
+    """
+
+    @wraps(func)
+    def wrapper(self, *args, **kwargs):
+        try:
+            return func(self, *args, **kwargs)
+        except errors.DeadlockDetected as e:
+            raise exc.DeadLock(code=e.sqlstate, message=str(e))
+        except (errors.UniqueViolation, errors.ForeignKeyViolation) as e:
+            raise exc.Conflict(code=e.sqlstate, message=str(e))
+
+    return wrapper
+
+
+class PgSQLInsert(base.BaseInsertCommand):
+
+    EXPRESSION = 'INSERT INTO "%s" (%s) VALUES (%s)'
+
+    @handle_database_errors
+    def execute(self):
+        """
+        Executes the PostgreSQL insert command.
+
+        This method utilizes the base class's execute method to perform the
+        command execution. It is decorated with `handle_database_errors` to
+        handle any PostgreSQL database errors that may occur during execution,
+        such as deadlocks or conflicts, and raise appropriate exceptions.
+
+        :return: The result of the command execution.
+        """
+        return super().execute()
+
+
+class PgSQLUpdate(base.BaseUpdateCommand):
+
+    EXPRESSION = 'UPDATE "%s" SET %s WHERE %s'
+
+    @handle_database_errors
+    def execute(self):
+        """
+        Executes the PostgreSQL update command.
+
+        This method utilizes the base class's execute method to perform the
+        command execution. It is decorated with `handle_database_errors` to
+        handle any PostgreSQL database errors that may occur during execution,
+        such as deadlocks or conflicts, and raise appropriate exceptions.
+
+        :return: The result of the command execution.
+        """
+        return super().execute()
+
+
+class PgSQLDelete(base.BaseDeleteCommand):
+
+    EXPRESSION = 'DELETE FROM "%s" WHERE %s'
+
+    @handle_database_errors
+    def execute(self):
+        """
+        Executes the PostgreSQL delete command.
+
+        This method utilizes the base class's execute method to perform the
+        command execution. It is decorated with `handle_database_errors` to
+        handle any PostgreSQL database errors that may occur during execution,
+        such as deadlocks or conflicts, and raise appropriate exceptions.
+
+        :return: The result of the command execution.
+        """
+        return super().execute()
+
+
+class PgSQLBatchDelete(base.BaseBatchDelete):
+
+    EXPRESSION_IN = 'DELETE FROM "%s" WHERE %s = ANY(%s)'
+    EXPRESSION_FILTER = 'DELETE FROM "%s" WHERE %s'
+
+    @handle_database_errors
+    def execute(self):
+        """
+        Executes the PostgreSQL batch delete command.
+
+        This method utilizes the base class's execute method to perform the
+        command execution. It is decorated with `handle_database_errors` to
+        handle any PostgreSQL database errors that may occur during execution,
+        such as deadlocks or conflicts, and raise appropriate exceptions.
+
+        :return: The result of the command execution.
+        """
+        return super().execute()
+
+
+class PgSQLSelect(base.BaseSelectCommand):
+
+    EXPRESSION = 'SELECT %s FROM "%s"'
+
+    @handle_database_errors
+    def execute(self):
+        """
+        Executes the PostgreSQL select command.
+
+        This method utilizes the base class's execute method to perform the
+        command execution. It is decorated with `handle_database_errors` to
+        handle any PostgreSQL database errors that may occur during execution,
+        such as deadlocks or conflicts, and raise appropriate exceptions.
+
+        :return: The result of the command execution.
+        """
+        return super().execute()
+
+
+class PgSQLCustomSelect(base.BaseCustomSelectCommand):
+
+    EXPRESSION = 'SELECT %s FROM "%s"'
+
+    @handle_database_errors
+    def execute(self):
+        """
+        Executes the PostgreSQL custom select command.
+
+        This method utilizes the base class's execute method to perform the
+        command execution. It is decorated with `handle_database_errors` to
+        handle any PostgreSQL database errors that may occur during execution,
+        such as deadlocks or conflicts, and raise appropriate exceptions.
+
+        :return: The result of the command execution.
+        """
+        return super().execute()
+
+
+class PgSQLCount(base.BaseCountCommand):
+
+    EXPRESSION = 'SELECT COUNT(*) as count FROM "%s"'
+
+    @handle_database_errors
+    def execute(self):
+        """
+        Executes the PostgreSQL count command.
+
+        This method utilizes the base class's execute method to perform the
+        command execution. It is decorated with `handle_database_errors` to
+        handle any PostgreSQL database errors that may occur during execution,
+        such as deadlocks or conflicts, and raise appropriate exceptions.
+
+        :return: The result of the command execution.
+        """
+        return super().execute()
+
+
+class PgSqlOrmDialectCommand(base.BaseOrmDialectCommand):
+
+    @handle_database_errors
+    def execute(self):
+        """
+        Executes the PostgreSQL ORM command.
+
+        This method compiles the query using the `get_statement` method and
+        retrieves the values required for the query execution using the
+        `get_values` method. Subsequently, it executes the SQL command using
+        the parent class's `execute` method, passing the compiled statement
+        and values to it. It is decorated with `handle_database_errors` to
+        handle any PostgreSQL database errors that may occur during execution,
+        such as deadlocks or conflicts, and raise appropriate exceptions.
+
+        :return: The result of the query execution.
+        """
+
+        return super().execute()
+
+
+class PgSQLDialect(base.AbstractDialect):
+
+    DIALECT_NAME = "postgresql"
+
+    def orm_command(self, table, query, session):
+        """
+        Creates a new PostgreSQL ORM command for the given table, query, and
+        session.
+
+        This method creates an instance of `PgSqlOrmDialectCommand` and
+        initializes it with the given table, query, and session.
+
+        :param table: The table to be used in the ORM dialect command.
+        :param query: The query object that contains the SQL query to be
+            compiled.
+        :param session: The session to be used for executing the command.
+        :return: The created PostgreSQL ORM command.
+        :rtype: PgSqlOrmDialectCommand
+        """
+
+        return PgSqlOrmDialectCommand(table, query, session=session)
+
+    def insert(self, table, data, session):
+        """
+        Inserts data into the specified table using a PostgreSQL dialect command.
+
+        This method creates an instance of `PgSQLInsert` to insert the
+        provided data into the given table within the specified session
+        context.
+
+        :param table: The table into which data is to be inserted.
+        :param data: The data to be inserted into the table.
+        :param session: The session to be used for executing the insert
+            command.
+        :return: An instance of `PgSQLInsert` configured with the table, data,
+            and session.
+        :rtype: PgSQLInsert
+        """
+        return PgSQLInsert(table, data, session=session)
+
+    def update(self, table, ids, data, session):
+        """
+        Updates records in the specified table using a PostgreSQL dialect
+        command.
+
+        This method creates an instance of `PgSQLUpdate` to update records
+        identified by the provided IDs in the given table with the specified
+        data within the session context.
+
+        :param table: The table where records are to be updated.
+        :param ids: The IDs of the records to be updated.
+        :param data: The data to update the records with.
+        :param session: The session to be used for executing the update
+            command.
+        :return: An instance of `PgSQLUpdate` configured with the table,
+            IDs, data, and session.
+        :rtype: PgSQLUpdate
+        """
+
+        return PgSQLUpdate(table, ids, data, session=session)
+
+    def delete(self, table, ids, session):
+        """
+        Deletes records from the specified table using a PostgreSQL dialect
+        command.
+
+        This method creates an instance of `PgSQLDelete` to delete
+        records identified by the provided IDs from the given table within
+        the session context.
+
+        :param table: The table from which records are to be deleted.
+        :param ids: The IDs of the records to be deleted.
+        :param session: The session to be used for executing the delete
+            command.
+        :return: An instance of `PgSQLDelete` configured with the table, IDs,
+            and session.
+        :rtype: PgSQLDelete
+        """
+
+        return PgSQLDelete(table, ids, session=session)
+
+    def select(
+        self,
+        table,
+        filters,
+        session,
+        limit=None,
+        order_by=None,
+        locked=False,
+    ):
+        """
+        Retrieves records from the specified table using a PostgreSQL dialect
+        command.
+
+        This method creates an instance of `PgSQLSelect` to select records
+        from the given table based on the provided filters, with optional
+        limit, order by, and locking constraints, within the session context.
+
+        :param table: The table from which records are to be retrieved.
+        :param filters: The filters to be used for selecting the records.
+        :param session: The session to be used for executing the select
+            command.
+        :param limit: The maximum number of records to be retrieved.
+        :type limit: int, optional
+        :param order_by: The ordering criteria for the selected records.
+        :param locked: Whether to lock the selected records for update.
+            Defaults to False.
+        :type locked: bool
+        :return: An instance of `PgSQLSelect` configured with the table,
+            filters, session, limit, order by, and locked parameters.
+        :rtype: PgSQLSelect
+        """
+        return PgSQLSelect(
+            table=table,
+            session=session,
+            filters=filters,
+            limit=limit,
+            order_by=order_by,
+            locked=locked,
+        )
+
+    def custom_select(
+        self,
+        table,
+        session,
+        where_conditions,
+        where_values,
+        limit=None,
+        order_by=None,
+        locked=False,
+    ):
+        """
+        Retrieves records from the specified table using a custom PostgreSQL
+        dialect command.
+
+        This method creates an instance of `PgSQLCustomSelect` to select
+        records from the given table based on the provided where conditions
+        and values, with optional limit, order by, and locking constraints,
+        within the session context.
+
+        :param table: The table from which records are to be retrieved.
+        :param session: The session to be used for executing the select
+            command.
+        :param where_conditions: The conditions for the WHERE clause in the
+            SQL statement.
+        :param where_values: The values for the WHERE clause in the SQL
+            statement.
+        :param limit: The maximum number of records to be retrieved.
+        :type limit: int, optional
+        :param order_by: The ordering criteria for the selected records.
+        :param locked: Whether to lock the selected records for update.
+            Defaults to False.
+        :type locked: bool
+        :return: An instance of `PgSQLCustomSelect` configured with the table,
+            where conditions, where values, session, limit, order by, and
+            locked parameters.
+        :rtype: PgSQLCustomSelect
+        """
+        return PgSQLCustomSelect(
+            table=table,
+            session=session,
+            where_conditions=where_conditions,
+            where_values=where_values,
+            limit=limit,
+            order_by=order_by,
+            locked=locked,
+        )
+
+    def count(self, table, filters, session):
+        """
+        Retrieves the count of records from the specified table based on the
+        provided filters.
+
+        This method creates an instance of `PgSQLCount` to count records
+        from the given table using the specified session and filters.
+
+        :param table: The table from which records are to be counted.
+        :param filters: The filters to be used for counting the records.
+        :param session: The session to be used for executing the count
+            command.
+        :return: An instance of `PgSQLCount` configured with the table,
+            filters, and session parameters.
+        :rtype: PgSQLCount
+        """
+        return PgSQLCount(
+            table=table,
+            session=session,
+            filters=filters,
+        )

--- a/restalchemy/storage/sql/engines.py
+++ b/restalchemy/storage/sql/engines.py
@@ -21,10 +21,12 @@ import logging
 from mysql.connector import pooling
 import six
 from six.moves.urllib import parse
+import psycopg_pool
 
 from restalchemy.common import singletons
 from restalchemy.storage.sql.dialect import adapters
 from restalchemy.storage.sql.dialect import mysql
+from restalchemy.storage.sql.dialect import pgsql
 from restalchemy.storage.sql import sessions
 
 
@@ -36,107 +38,201 @@ LOG = logging.getLogger(__name__)
 @six.add_metaclass(abc.ABCMeta)
 class AbstractEngine(object):
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def URL_SCHEMA(self):
+        """
+        The URL schema for the database engine.
+
+        This abstract property should be overridden by subclasses to specify
+        the schema used in the database connection URL (e.g., "postgresql").
+        """
         raise NotImplementedError()
 
-    def __init__(self, db_url):
+    @property
+    @abc.abstractmethod
+    def DEFAULT_PORT(self):
+        """The default port number used by the database engine.
+
+        This abstract property should be overridden by subclasses to specify
+        the default port number used by the database engine if it is not
+        specified in the database connection URL.
+        """
+        raise NotImplementedError()
+
+    def __init__(
+        self,
+        db_url,
+        dialect,
+        session_storage,
+        config=None,
+        query_cache=False,
+    ):
+        """
+        Initializes the database engine.
+
+        :param db_url: The URL of the database connection.
+        :param dialect: The SQL dialect used by the database engine.
+        :param session_storage: The type of session storage used by the engine.
+        :param config: A dictionary of configuration options for the engine.
+        :param query_cache: A boolean indicating whether the engine should
+                            cache query results.
+
+        :raises ValueError: If the database URL does not match the expected
+            format.
+        """
         super(AbstractEngine, self).__init__()
         self._db_url = parse.urlparse(db_url)
 
-    @abc.abstractproperty
-    def db_name(self):
-        raise NotImplementedError()
-
-    @abc.abstractproperty
-    def db_username(self):
-        raise NotImplementedError()
-
-    @abc.abstractproperty
-    def db_password(self):
-        raise NotImplementedError()
-
-
-class MySQLEngine(AbstractEngine):
-
-    URL_SCHEMA = "mysql"
-
-    def __init__(self, db_url, config=None, query_cache=False):
-        super(MySQLEngine, self).__init__(db_url)
         if self._db_url.scheme != self.URL_SCHEMA:
             raise ValueError(
-                "Database url should be starts with mysql://. "
-                "For example: mysql://username:password@"
-                "127.0.0.1:3306/database_name"
+                "Database url should be starts with "
+                f"{self.URL_SCHEMA}://. For example: "
+                "mysql://<username>:[password]@"
+                "<host>:[port]/<database_name>"
             )
-        config = config or {}
+
         self._db_name = self._db_url.path[1:]
-        if "connection_timeout" not in config:
-            config["connection_timeout"] = DEFAULT_CONNECTION_TIMEOUT
-        config.update(
-            {
-                "user": self.db_username,
-                "password": self.db_password,
-                "database": self.db_name,
-                "host": self.db_host,
-                "port": self.db_port,
-                "converter_class": adapters.MySQLConverter,
-            }
-        )
-
-        try:
-            self._pool = pooling.MySQLConnectionPool(**config)
-        except AttributeError as e:
-            pool_name = e.args[0].split("'")[1]
-            new_name = str(hash(pool_name))
-            LOG.warning("Changing '%s' pool name to '%s'", pool_name, new_name)
-            config["pool_name"] = new_name
-            self._pool = pooling.MySQLConnectionPool(**config)
-
-        self._dialect = mysql.MySQLDialect()
-        self._session_storage = sessions.SessionThreadStorage()
+        self._config = config or {}
+        self._dialect = dialect
+        self._session_storage = session_storage
         self._query_cache = query_cache
-
-    def __del__(self):
-        pool = getattr(self, "_pool", None)
-        if pool is not None:
-            self._pool._remove_connections()
-
-    @property
-    def query_cache(self):
-        return self._query_cache
 
     @property
     def dialect(self):
+        """
+        Returns the SQL dialect used by the database engine.
+
+        :return: The SQL dialect used by the database engine.
+        :rtype: AbstractDialect
+        """
         return self._dialect
+
+    def escape(self, value):
+        """
+        Escapes a value for use in a query.
+
+        Escapes a value by wrapping it in backticks. This is a common way to
+        escape values in SQL queries.
+
+        :param value: The value to be escaped.
+        :return: The escaped value.
+        :rtype: str
+        """
+        return "`%s`" % value
 
     @property
     def db_name(self):
+        """
+        Returns the name of the database.
+
+        This property retrieves the database name from the parsed URL of the
+        database connection, which is stored during the initialization of the
+        engine instance.
+        """
+
         return self._db_name
 
     @property
     def db_username(self):
+        """
+        Returns the username used for the database connection.
+
+        This property retrieves the username from the parsed URL of the
+        database connection, which is stored during the initialization of the
+        engine instance.
+        """
         return self._db_url.username
 
     @property
     def db_password(self):
+        """
+        Returns the password used for the database connection.
+
+        This property retrieves the password from the parsed URL of the
+        database connection, which is stored during the initialization of the
+        engine instance.
+        """
         return self._db_url.password
 
     @property
     def db_host(self):
+        """
+        Returns the hostname used for the database connection.
+
+        This property retrieves the hostname from the parsed URL of the
+        database connection, which is stored during the initialization of the
+        engine instance.
+        """
         return self._db_url.hostname
 
     @property
     def db_port(self):
-        return self._db_url.port or 3306
+        """
+        Returns the port number used for the database connection.
+
+        If the port number was not specified in the database connection URL,
+        the default port number for the engine is used instead.
+
+        Returns:
+            The port number used for the database connection.
+        """
+        return self._db_url.port or self.DEFAULT_PORT
+
+    @property
+    def query_cache(self):
+        """
+        Returns a boolean indicating whether the query cache is enabled.
+
+        The query cache can be set when the engine is initialized, and it
+        determines whether the engine should cache the results of queries
+        using the session's query cache.
+
+        Returns:
+            A boolean indicating whether the query cache is enabled.
+        """
+        return self._query_cache
 
     def get_connection(self):
-        return self._pool.get_connection()
+        """
+        Establishes and returns a connection to the database from a pool.
+
+        This method should be implemented by subclasses to provide the logic
+        for connecting to a specific database using the engine's
+        configuration.
+
+        Returns:
+            A database connection object.
+
+        Raises:
+            NotImplementedError: If the method is not implemented by a
+            subclass.
+        """
+        raise NotImplementedError()
 
     def get_session(self):
-        return sessions.MySQLSession(engine=self)
+        """
+        Returns a session object for the engine. This method can be used to
+        explicitly start a session, or to get the session object from the
+        current context.
+
+        Returns:
+            A session object.
+
+        Raises:
+            NotImplementedError: If the method is not implemented by a
+            subclass.
+        """
+        raise NotImplementedError()
 
     def _get_session_from_storage(self):
+        """
+        Retrieve a session object from the session storage associated with
+        this engine.
+
+        :returns: A session object, or None if no session is stored.
+        :rtype: Session or None
+        """
         try:
             return self.get_session_storage().get_session()
         except sessions.SessionNotFound:
@@ -144,6 +240,23 @@ class MySQLEngine(AbstractEngine):
 
     @contextlib.contextmanager
     def session_manager(self, session=None):
+        """
+        Context manager for managing a database session.
+
+        This method provides a context for executing database operations within
+        a session. If a session is not provided, it attempts to retrieve one
+        from storage or creates a new session. The session is automatically
+        committed if no exceptions occur, otherwise it is rolled back. The
+        session is always closed when the context exits.
+
+        :param session: An optional session object. If not provided, a session
+            is retrieved from storage or a new one is created.
+        :type session: Optional[Session]
+        :yields: The active session for database operations.
+        :raises Exception: Any exceptions raised during the session's execution
+            will result in a rollback of the session.
+        """
+
         session = session or self._get_session_from_storage()
         if session is None:
             session = self.get_session()
@@ -159,23 +272,280 @@ class MySQLEngine(AbstractEngine):
             yield session
 
     def get_session_storage(self):
+        """
+        Returns the session storage object for the engine.
+
+        The session storage object is used to store session objects for the
+        engine. This allows the engine to maintain a consistent session
+        object across different threads and contexts.
+
+        Returns:
+            The session storage object.
+        """
         return self._session_storage
+
+    def close_connection(self, conn):
+        """
+        Closes the provided connection.
+
+        This method closes a database connection. It is typically used to
+        release resources associated with the connection once database
+        operations are completed.
+
+        :param conn: The connection to be closed.
+        :type conn: Connection object
+        """
+
+        conn.close()
+
+
+class PgSQLEngine(AbstractEngine):
+
+    URL_SCHEMA = "postgresql"
+    DEFAULT_PORT = 5432
+
+    def __init__(self, db_url, config=None, query_cache=False):
+        """
+        Initializes the PostgreSQL engine.
+
+        :param db_url: The connection URL for the PostgreSQL database.
+        :param config: A dictionary of configuration options for the engine.
+        :param query_cache: A boolean indicating whether the engine should
+            cache query results.
+
+        :return: The initialized engine.
+        """
+
+        super(PgSQLEngine, self).__init__(
+            db_url=db_url,
+            dialect=pgsql.PgSQLDialect(),
+            session_storage=sessions.SessionThreadStorage(),
+            config=config,
+            query_cache=query_cache,
+        )
+        self._pool = psycopg_pool.ConnectionPool(
+            conninfo=db_url,
+            **self._config,
+        )
+        self._pool.wait()
+
+    def escape(self, value):
+        """
+        Escapes a value for use in a PostgreSQL query.
+
+        This method is used by the :py:class:`PgSQLSession` class to escape
+        values before they are used in a query. It is not intended to be used
+        directly by applications.
+
+        The value is escaped by wrapping it in double quotes. This is because
+        double quotes are used to delimit strings in PostgreSQL, and the value
+        is already escaped if it is a string.
+
+        :param value: The value to be escaped.
+        :return: The escaped value.
+        """
+
+        return '"' + value + '"'
+
+    def __del__(self):
+        """
+        Closes the connection pool to the PostgreSQL database before the
+        engine instance is garbage collected.
+
+        This method is called when the engine instance is garbage collected
+        to ensure that the connection pool is closed and any resources
+        acquired by the pool are released.
+
+        Note that the connection pool is not closed until the engine instance
+        is garbage collected, which may not happen immediately. Therefore,
+        this method is not suitable for use in applications where it is
+        important to release resources immediately after they are no longer
+        needed.
+
+        :raises psycopg2.Error: If an error occurs while closing the pool.
+        """
+
+        self._pool.close()
+
+    def get_session(self):
+        """
+        Creates and returns a new PgSQLSession instance for the current engine.
+
+        This method initializes a session object that can be used to interact
+        with the PostgreSQL database associated with this engine.
+
+        :returns: A session object for database operations.
+        :rtype: PgSQLSession
+        """
+
+        return sessions.PgSQLSession(engine=self)
+
+    def get_connection(self):
+        """
+        Retrieves a connection from the pool.
+
+        This method is used to acquire a PostgreSQL connection from the pool
+        of connections managed by the engine. The connection is used to
+        execute queries and other database operations.
+
+        :returns: A connection object for database operations.
+        :rtype: psycopg2.extensions.connection
+        """
+
+        return self._pool.getconn()
+
+    def close_connection(self, conn):
+        """
+        Releases a connection back to the pool.
+
+        This method checks if the provided connection is closed. If the
+        connection is closed, it returns `None` to the pool, indicating
+        that the connection should be discarded. Otherwise, it returns
+        the connection back to the pool for reuse.
+
+        :param conn: The connection to be released back to the pool.
+        :type conn: psycopg2.extensions.connection
+        """
+
+        if conn.closed:
+            self._pool.putconn(None)
+        else:
+            self._pool.putconn(conn)
+
+
+class MySQLEngine(AbstractEngine):
+
+    URL_SCHEMA = "mysql"
+    DEFAULT_PORT = 3306
+
+    def __init__(self, db_url, config=None, query_cache=False):
+        """
+        Initializes the MySQL engine.
+
+        :param db_url: The URL of the database connection.
+        :param config: A dictionary of configuration options for the engine.
+        :param query_cache: A boolean indicating whether the engine should
+            cache query results.
+
+        :raises ValueError: If the database URL does not match the expected
+            format.
+        """
+        super(MySQLEngine, self).__init__(
+            db_url=db_url,
+            dialect=mysql.MySQLDialect(),
+            session_storage=sessions.SessionThreadStorage(),
+            config=config,
+            query_cache=query_cache,
+        )
+
+        if "connection_timeout" not in self._config:
+            self._config["connection_timeout"] = DEFAULT_CONNECTION_TIMEOUT
+        self._config.update(
+            {
+                "user": self.db_username,
+                "password": self.db_password,
+                "database": self.db_name,
+                "host": self.db_host,
+                "port": self.db_port,
+                "converter_class": adapters.MySQLConverter,
+            }
+        )
+
+        try:
+            self._pool = pooling.MySQLConnectionPool(**self._config)
+        except AttributeError as e:
+            pool_name = e.args[0].split("'")[1]
+            new_name = str(hash(pool_name))
+            LOG.warning("Changing '%s' pool name to '%s'", pool_name, new_name)
+            config["pool_name"] = new_name
+            self._pool = pooling.MySQLConnectionPool(**self._config)
+
+    def __del__(self):
+        """
+        Closes the connection pool to the MySQL database before the engine
+        instance is garbage collected.
+
+        This method is called when the engine instance is garbage collected to
+        ensure that the connection pool is closed and any resources acquired by
+        the pool are released.
+        """
+        pool = getattr(self, "_pool", None)
+        if pool is not None:
+            self._pool._remove_connections()
+
+    def get_connection(self):
+        """
+        Retrieves a connection from the pool.
+
+        This method is used to acquire a connection from the pool of
+        connections managed by the engine. The connection is used to
+        execute queries and other database operations.
+
+        :returns: A connection object for database operations.
+        :rtype: mysql.connector.connection.MySQLConnection
+        """
+        return self._pool.get_connection()
+
+    def get_session(self):
+        """
+        Creates and returns a new MySQLSession instance for the current engine.
+
+        This method initializes a session object that can be used to interact
+        with the MySQL database associated with this engine.
+
+        :returns: A session object for database operations.
+        :rtype: MySQLSession
+        """
+        return sessions.MySQLSession(engine=self)
 
 
 class EngineFactory(singletons.InheritSingleton):
 
     def __init__(self):
+        """
+        Initializes the engine factory singleton.
+
+        This method is called when the singleton is created. It initializes the
+        internal state of the factory by creating an empty dictionary to store
+        engine instances and a mapping of database URLs to engine classes.
+
+        :returns: None
+        """
         super(EngineFactory, self).__init__()
         self._engines = {}
-        self._engines_map = {MySQLEngine.URL_SCHEMA: MySQLEngine}
+        self._engines_map = {
+            MySQLEngine.URL_SCHEMA: MySQLEngine,
+            PgSQLEngine.URL_SCHEMA: PgSQLEngine,
+        }
 
     def configure_factory(
-        self, db_url, config=None, query_cache=False, name=DEFAULT_NAME
+        self,
+        db_url,
+        config=None,
+        query_cache=False,
+        name=DEFAULT_NAME,
     ):
-        """Configure_factory
-
-        @property db_url: str. For example driver://user:passwd@host:port/db
         """
+        Configures and creates a new database engine instance for the given
+        URL.
+
+        This method initializes a database engine based on the provided
+        database URL, configuration options, and query caching preference. The
+        initialized engine is stored in the factory's internal engines
+        dictionary, keyed by the specified name.
+
+        :param db_url: The database connection URL.
+        :param config: A dictionary of configuration options for the engine.
+                    Defaults to None.
+        :param query_cache: A boolean indicating whether the engine should
+                            cache query results. Defaults to False.
+        :param name: The name under which to store the initialized engine in
+                     the factory. Defaults to 'default'.
+
+        :raises ValueError: If the schema from the db_url is not supported
+                            or if no driver is found for the schema.
+        """
+
         schema = db_url.split(":")[0]
         try:
             self._engines[name] = self._engines_map[schema.lower()](
@@ -185,21 +555,51 @@ class EngineFactory(singletons.InheritSingleton):
             raise ValueError("Can not find driver for schema %s" % schema)
 
     def get_engine(self, name=DEFAULT_NAME):
+        """
+        Returns an engine instance from the factory's internal engines
+        dictionary by name. If the specified engine name does not exist,
+        a ValueError is raised.
+
+        :param name: The name of the engine to return. Defaults to 'default'.
+        :return: An engine instance.
+        :raises ValueError: If the specified engine name is not found in the
+                            factory's internal engines dictionary.
+        """
         engine = self._engines.get(name, None)
         if engine:
             return engine
         raise ValueError(
-            ("Can not return %s engine. Please configure" " EngineFactory")
-            % name
+            ("Can not return %s engine. Please configure EngineFactory")
+            % name,
         )
 
     def destroy_engine(self, name=DEFAULT_NAME):
+        """
+        Removes and destroys the engine instance associated with the specified
+        name from the factory's internal engines dictionary.
+
+        This method attempts to delete the engine instance identified by the
+        given name. If the engine instance does not exist, the method silently
+        handles the KeyError exception.
+
+        :param name: The name of the engine to destroy. Defaults to 'default'.
+        """
+
         try:
             del self._engines[name]
         except KeyError:
             pass
 
     def destroy_all_engines(self):
+        """
+        Removes and destroys all engine instances from the factory's internal
+        engines dictionary.
+
+        This method resets the factory to its initial state, removing all
+        configured engines. Subsequent calls to get_engine() will raise a
+        ValueError until at least one engine is configured using
+        configure_factory().
+        """
         self._engines = {}
 
 
@@ -208,10 +608,26 @@ class DBConnectionUrl(object):
     _CENSORED = ":<censored>@"
 
     def __init__(self, db_url):
+        """
+        Initializes a DBConnectionUrl instance with the provided database URL.
+
+        :param db_url: The URL of the database connection, which will be
+                       parsed and stored.
+        """
+
         super(DBConnectionUrl, self).__init__()
         self._db_url = parse.urlparse(db_url)
 
     def __repr__(self):
+        """
+        Returns a string representation of the DBConnectionUrl instance.
+
+        The string representation is generated by replacing the password
+        substring in the original URL with the value of _CENSORED, to prevent
+        the password from being displayed.
+
+        :return: A string representation of the DBConnectionUrl instance.
+        """
         if self._db_url.password is None:
             orig_substr = "@"
         else:
@@ -220,6 +636,15 @@ class DBConnectionUrl(object):
 
     @property
     def url(self):
+        """
+        Returns the full URL string of the database connection.
+
+        This property retrieves the complete URL by converting the parsed
+        URL components back into a string representation. It is useful for
+        obtaining the original connection URL, with the password censored
+        if applicable, after it has been parsed and stored.
+        """
+
         return self._db_url.geturl()
 
 

--- a/restalchemy/storage/sql/migrations.py
+++ b/restalchemy/storage/sql/migrations.py
@@ -83,15 +83,21 @@ class AbstarctMigrationStep(object):
 
     @staticmethod
     def _delete_table_if_exists(session, table_name):
-        session.execute("DROP TABLE IF EXISTS `%s`;" % table_name, None)
+        session.execute(
+            f"DROP TABLE IF EXISTS {session.engine.escape(table_name)};"
+        )
 
     @staticmethod
     def _delete_trigger_if_exists(session, trigger_name):
-        session.execute("DROP TRIGGER IF EXISTS `%s`;" % trigger_name, None)
+        session.execute(
+            f"DROP TRIGGER IF EXISTS {session.engine.escape(trigger_name)};"
+        )
 
     @staticmethod
     def _delete_view_if_exists(session, view_name):
-        session.execute("DROP VIEW IF EXISTS `%s`;" % view_name, None)
+        session.execute(
+            f"DROP VIEW IF EXISTS {session.engine.escape(view_name)};"
+        )
 
 
 class MigrationModel(models.ModelWithUUID, orm.SQLStorableMixin):
@@ -288,17 +294,10 @@ class MigrationEngine(object):
 
     @staticmethod
     def _init_migration_table(session):
-        statement = (
-            (
-                """CREATE TABLE IF NOT EXISTS %s (
-            uuid CHAR(36) NOT NULL,
-            applied BIT(1) NOT NULL,
-            PRIMARY KEY (uuid)
-        ) ENGINE=InnoDB DEFAULT CHARSET=utf8
-        """
-            )
-            % RA_MIGRATION_TABLE_NAME
-        )
+        statement = f"""CREATE TABLE IF NOT EXISTS {RA_MIGRATION_TABLE_NAME} (
+            uuid CHAR(36) NOT NULL PRIMARY KEY,
+            applied BOOLEAN NOT NULL
+        )"""
         session.execute(statement, None)
 
     def _load_migrations(self):

--- a/restalchemy/storage/sql/orm.py
+++ b/restalchemy/storage/sql/orm.py
@@ -168,7 +168,7 @@ class ObjectCollection(
                 engine=self._engine, session=s, filters=filters
             )
             data = list(result.fetchall())
-            return data[0]["COUNT"]
+            return data[0]["count"]
 
 
 class UndefinedAttribute(common_exc.RestAlchemyException):

--- a/restalchemy/storage/sql/sessions.py
+++ b/restalchemy/storage/sql/sessions.py
@@ -19,9 +19,12 @@ import logging
 import threading
 
 from mysql.connector import errors
+from psycopg import rows as pg_rows
+from psycopg import errors as pg_errors
 
 from restalchemy.storage import exceptions as exc
 from restalchemy.storage.sql.dialect import mysql
+from restalchemy.storage.sql.dialect import pgsql
 
 
 LOG = logging.getLogger(__name__)
@@ -112,17 +115,21 @@ class SessionQueryCache(object):
         return self.__query_cache[query_hash]
 
 
-class MySQLSession(object):
+class PgSQLSession(object):
 
     def __init__(self, engine):
         self._engine = engine
         self._conn = self._engine.get_connection()
-        self._cursor = self._conn.cursor(dictionary=True, buffered=True)
+        self._cursor = self._conn.cursor(row_factory=pg_rows.dict_row)
         self._log = LOG
         self.cache = SessionQueryCache(session=self)
 
+    @property
+    def engine(self):
+        return self._engine
+
     @staticmethod
-    def _all_model_is_same_type(target_model, models):
+    def _check_models_same_type(target_model, models):
         model_type = type(target_model)
         if not min(map(lambda m: isinstance(m, model_type), models)):
             raise TypeError("All models in the list must be of the same type")
@@ -131,39 +138,38 @@ class MySQLSession(object):
         if models:
             # Check models type
             first_model = models[0]
-            self._all_model_is_same_type(first_model, models)
+            self._check_models_same_type(first_model, models)
 
             # process values
             values = []
             table = first_model.get_table()
-            statement = mysql.MySQLInsert(
-                table,
-                first_model.get_storable_snapshot(),
+            statement = pgsql.PgSQLInsert(
+                table=table,
+                data=first_model.get_storable_snapshot(),
+                session=self,
             ).get_statement()
             for model in models:
                 snapshot = model.get_storable_snapshot()
-                insert = mysql.MySQLInsert(table, snapshot)
+                insert = pgsql.PgSQLInsert(
+                    table=table,
+                    data=snapshot,
+                    session=self,
+                )
                 values.append(insert.get_values())
 
             try:
                 return self.execute_many(statement, values)
-            except errors.IntegrityError as e:
-                # Error codes from Maria DB documentation. See more on website
-                # https://mariadb.com/kb/en/mariadb-error-codes/
-                # Errno: 1062 and sqlstate: 23000 is "Duplicate entry" error.
-                if e.errno == 1062 and e.sqlstate == "23000":
-                    raise exc.ConflictRecords(
-                        model=type(first_model).__name__,
-                        msg=e.msg,
-                    )
-                else:
-                    raise exc.UnknownStorageException(caused=e)
+            except pg_errors.UniqueViolation as e:
+                raise exc.ConflictRecords(
+                    model=type(first_model).__name__,
+                    msg=str(e),
+                )
 
     def batch_delete(self, models):
         if models:
             # Check models type
             first_model = models[0]
-            self._all_model_is_same_type(first_model, models)
+            self._check_models_same_type(first_model, models)
 
             # process values
             table = first_model.get_table()
@@ -175,9 +181,10 @@ class MySQLSession(object):
                         prop.value
                     )
                 values.append(pk_values)
-            operation = mysql.MySQLBatchDelete(
-                table,
-                values,
+            operation = pgsql.PgSQLBatchDelete(
+                table=table,
+                snapshot=values,
+                session=self,
             )
 
             return self.execute(
@@ -198,7 +205,130 @@ class MySQLSession(object):
             )
             self._cursor.execute(statement, values)
             return self._cursor
-        except errors.DatabaseError as e:
+        except errors.DatabaseError:
+            raise
+
+    def execute_many(self, statement, values):
+        self._log.debug(
+            (
+                "Execute batch statement %s"
+                " with values %s"
+                " within %s database"
+            ),
+            statement,
+            values,
+            self._engine.db_name,
+        )
+        self._cursor.executemany(statement, values)
+        return self._cursor
+
+    def rollback(self):
+        self._conn.rollback()
+
+    def commit(self):
+        self._conn.commit()
+
+    def close(self):
+        self._engine.close_connection(self._conn)
+
+
+class MySQLSession(object):
+
+    def __init__(self, engine):
+        self._engine = engine
+        self._conn = self._engine.get_connection()
+        self._cursor = self._conn.cursor(dictionary=True, buffered=True)
+        self._log = LOG
+        self.cache = SessionQueryCache(session=self)
+
+    @property
+    def engine(self):
+        return self._engine
+
+    @staticmethod
+    def _check_models_same_type(target_model, models):
+        model_type = type(target_model)
+        if not min(map(lambda m: isinstance(m, model_type), models)):
+            raise TypeError("All models in the list must be of the same type")
+
+    def batch_insert(self, models):
+        if models:
+            # Check models type
+            first_model = models[0]
+            self._check_models_same_type(first_model, models)
+
+            # process values
+            values = []
+            table = first_model.get_table()
+            statement = mysql.MySQLInsert(
+                table=table,
+                data=first_model.get_storable_snapshot(),
+                session=self,
+            ).get_statement()
+            for model in models:
+                snapshot = model.get_storable_snapshot()
+                insert = mysql.MySQLInsert(
+                    table=table,
+                    data=snapshot,
+                    session=self,
+                )
+                values.append(insert.get_values())
+
+            try:
+                return self.execute_many(statement, values)
+            except errors.IntegrityError as e:
+                # Error codes from Maria DB documentation. See more on website
+                # https://mariadb.com/kb/en/mariadb-error-codes/
+                # Errno: 1062 and sqlstate: 23000 is "Duplicate entry" error.
+                if e.errno == 1062 and e.sqlstate == "23000":
+                    raise exc.ConflictRecords(
+                        model=type(first_model).__name__,
+                        msg=e.msg,
+                    )
+                else:
+                    raise exc.UnknownStorageException(caused=e)
+
+    def batch_delete(self, models):
+        if models:
+            # Check models type
+            first_model = models[0]
+            self._check_models_same_type(first_model, models)
+
+            # process values
+            table = first_model.get_table()
+            values = []
+            for model in models:
+                pk_values = {}
+                for name, prop in model.get_id_properties().items():
+                    pk_values[name] = prop.property_type.to_simple_type(
+                        prop.value
+                    )
+                values.append(pk_values)
+            operation = mysql.MySQLBatchDelete(
+                table=table,
+                snapshot=values,
+                session=self,
+            )
+
+            return self.execute(
+                operation.get_statement(), operation.get_values()
+            )
+
+    def execute(self, statement, values=None):
+        try:
+            self._log.debug(
+                (
+                    "Execute statement %s"
+                    " with values %s"
+                    " within %s database"
+                ),
+                statement,
+                values,
+                self._engine.db_name,
+            )
+            self._cursor.execute(statement, values)
+            return self._cursor
+        except errors.DatabaseError as e:  ####### ???
             if e.errno == 1213:
                 raise exc.DeadLock(msg=e.msg)
             raise
@@ -224,7 +354,7 @@ class MySQLSession(object):
         self._conn.commit()
 
     def close(self):
-        self._conn.close()
+        self._engine.close_connection(self._conn)
 
 
 @contextlib.contextmanager

--- a/restalchemy/tests/fixtures.py
+++ b/restalchemy/tests/fixtures.py
@@ -1,0 +1,45 @@
+# Copyright 2019 Eugene Frolov
+#
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import mock
+
+
+class DialectFixture(mock.Mock):
+
+    @property
+    def name(self):
+        return "mysql"
+
+
+class EngineFixture(mock.Mock):
+
+    def escape(self, value):
+        return f"`{value}`"
+
+    @property
+    def dialect(self):
+        return DialectFixture()
+
+
+class SessionFixture(mock.Mock):
+
+    @property
+    def engine(self):
+        return EngineFixture()
+
+    @engine.setter
+    def engine(self, value):
+        pass

--- a/restalchemy/tests/functional/migrations/0001-rest-service-tables-migration-e31a12.py
+++ b/restalchemy/tests/functional/migrations/0001-rest-service-tables-migration-e31a12.py
@@ -35,10 +35,10 @@ class MigrationStep(migrations.AbstarctMigrationStep):
                     name VARCHAR(255) NOT NULL,
                     just_none VARCHAR(255) NULL,
                     status VARCHAR(255) NULL,
-                    `created` DATETIME(6) DEFAULT NOW(),
-                    `updated` DATETIME(6) DEFAULT NOW(),
+                    created TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP,
+                    updated TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP,
                     PRIMARY KEY (uuid)
-                ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+                );
             """,
             """
                 CREATE TABLE IF NOT EXISTS ports (
@@ -46,30 +46,27 @@ class MigrationStep(migrations.AbstarctMigrationStep):
                     mac CHAR(17) NOT NULL,
                     vm CHAR(36) NOT NULL,
                     PRIMARY KEY (uuid),
-                    CONSTRAINT FOREIGN KEY ix_vms_uuid (vm)
-                    REFERENCES vms (uuid)
-                ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+                    FOREIGN KEY (vm) REFERENCES vms (uuid)
+                );
             """,
             """
                 CREATE TABLE IF NOT EXISTS ip_addresses (
                     uuid CHAR(36) NOT NULL,
-                    ip CHAR(17) NOT NULL,
+                    ip VARCHAR(17) NOT NULL,
                     port CHAR(36) NOT NULL,
                     PRIMARY KEY (uuid),
-                    CONSTRAINT FOREIGN KEY ix_ports_uuid (port)
-                    REFERENCES ports (uuid)
-                ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+                    FOREIGN KEY (port) REFERENCES ports (uuid)
+                );
             """,
             """
                 CREATE TABLE IF NOT EXISTS tags (
                     uuid CHAR(36) NOT NULL,
                     vm CHAR(36) NOT NULL,
-                    name CHAR(40) NOT NULL,
-                    visible BOOL NOT NULL,
+                    name VARCHAR(40) NOT NULL,
+                    visible BOOLEAN NOT NULL,
                     PRIMARY KEY (uuid),
-                    CONSTRAINT FOREIGN KEY ix_tags__vms_uuid (vm)
-                    REFERENCES vms (uuid)
-                ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+                    FOREIGN KEY (vm) REFERENCES vms (uuid)
+                );
             """,
         ]
 

--- a/restalchemy/tests/functional/migrations/0001-test-bug-29808262-743d38.py
+++ b/restalchemy/tests/functional/migrations/0001-test-bug-29808262-743d38.py
@@ -33,11 +33,10 @@ class MigrationStep(migrations.AbstarctMigrationStep):
     def upgrade(self, session):
         expressions = [
             """
-                CREATE TABLE IF NOT EXISTS `binary_data` (
-                    `uuid` CHAR(36) NOT NULL,
-                    `data` TEXT NOT NULL,
-                PRIMARY KEY (`uuid`))
-                ENGINE=InnoDB DEFAULT CHARSET=utf8;
+                CREATE TABLE IF NOT EXISTS binary_data (
+                    uuid CHAR(36) NOT NULL,
+                    data TEXT NOT NULL,
+                PRIMARY KEY (uuid))
             """
         ]
         for expression in expressions:

--- a/restalchemy/tests/functional/migrations/0002-0-rest-service-data-for-test-nested-resource-c17a60.py
+++ b/restalchemy/tests/functional/migrations/0002-0-rest-service-data-for-test-nested-resource-c17a60.py
@@ -29,13 +29,9 @@ class MigrationStep(migrations.AbstarctMigrationStep):
     def upgrade(self, session):
         expressions = [
             """
-                INSERT INTO vms (
-                     `uuid`, `name`, `state`
-                ) VALUES (
-                    '00000000-0000-0000-0000-000000000001', 'vm1', 'on'
-                ), (
-                    '00000000-0000-0000-0000-000000000002', 'vm2', 'off'
-                );
+                INSERT INTO vms (uuid, name, state)
+                VALUES ('00000000-0000-0000-0000-000000000001', 'vm1', 'on'),
+                       ('00000000-0000-0000-0000-000000000002', 'vm2', 'off');
             """
         ]
 

--- a/restalchemy/tests/functional/migrations/0002-1-rest-service-data-for-test-unpacker-1a9112.py
+++ b/restalchemy/tests/functional/migrations/0002-1-rest-service-data-for-test-unpacker-1a9112.py
@@ -30,14 +30,14 @@ class MigrationStep(migrations.AbstarctMigrationStep):
         expressions = [
             """
                 INSERT INTO vms (
-                     `uuid`, `name`, `state`
+                     uuid, name, state
                 ) VALUES (
                     '00000000-0000-0000-0000-000000000001', 'vm1', 'on'
                 );
             """,
             """
                 INSERT INTO ports (
-                     `uuid`, `mac`, `vm`
+                     uuid, mac, vm
                 ) VALUES (
                     '00000000-0000-0000-0000-000000000002',
                     '00:00:00:00:00:00',
@@ -46,7 +46,7 @@ class MigrationStep(migrations.AbstarctMigrationStep):
             """,
             """
                 INSERT INTO ip_addresses (
-                     `uuid`, `ip`, `port`
+                     uuid, ip, port
                 ) VALUES (
                     '00000000-0000-0000-0000-000000000003',
                     '192.168.0.1',

--- a/restalchemy/tests/functional/migrations/prefetch-relationship-tests-f3841e.py
+++ b/restalchemy/tests/functional/migrations/prefetch-relationship-tests-f3841e.py
@@ -32,122 +32,122 @@ class MigrationStep(migrations.AbstarctMigrationStep):
                 CREATE TABLE IF NOT EXISTS root (
                     uuid CHAR(36) NOT NULL,
                     field_str VARCHAR(255) NOT NULL,
-                    field_int INT(11) NOT NULL,
+                    field_int INT NOT NULL,
                     field_bool BOOL NOT NULL,
                     PRIMARY KEY (uuid)
-                ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+                );
             """,
             """
                 CREATE TABLE IF NOT EXISTS lnp1_1 (
                     uuid CHAR(36) NOT NULL,
                     root CHAR(36) NOT NULL,
                     field_str VARCHAR(255) NOT NULL,
-                    field_int INT(11) NOT NULL,
+                    field_int INT NOT NULL,
                     field_bool BOOL NOT NULL,
                     PRIMARY KEY (uuid),
-                    CONSTRAINT `fk_lnp1_1_root_uuid` FOREIGN KEY (`root`)
-                        REFERENCES `root` (`uuid`)
+                    FOREIGN KEY (root)
+                        REFERENCES root (uuid)
                         ON DELETE RESTRICT
                         ON UPDATE RESTRICT
-                ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+                );
             """,
             """
                 CREATE TABLE IF NOT EXISTS lnp1_2 (
                     uuid CHAR(36) NOT NULL,
                     root CHAR(36),
                     field_str VARCHAR(255) NOT NULL,
-                    field_int INT(11) NOT NULL,
+                    field_int INT NOT NULL,
                     field_bool BOOL NOT NULL,
                     PRIMARY KEY (uuid),
-                    CONSTRAINT `fk_lmp1_2_root_uuid` FOREIGN KEY (`root`)
-                        REFERENCES `root` (`uuid`)
+                    FOREIGN KEY (root)
+                        REFERENCES root (uuid)
                         ON DELETE RESTRICT
                         ON UPDATE RESTRICT
-                ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+                );
             """,
             """
                 CREATE TABLE IF NOT EXISTS lwp1_1 (
                     uuid CHAR(36) NOT NULL,
                     root CHAR(36) NOT NULL,
                     field_str VARCHAR(255) NOT NULL,
-                    field_int INT(11) NOT NULL,
+                    field_int INT NOT NULL,
                     field_bool BOOL NOT NULL,
                     PRIMARY KEY (uuid),
-                    CONSTRAINT `fk_lwp1_1_root_uuid` FOREIGN KEY (`root`)
-                        REFERENCES `root` (`uuid`)
+                    FOREIGN KEY (root)
+                        REFERENCES root (uuid)
                         ON DELETE RESTRICT
                         ON UPDATE RESTRICT
-                ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+                );
             """,
             """
                 CREATE TABLE IF NOT EXISTS lwp1_2 (
                     uuid CHAR(36) NOT NULL,
                     root CHAR(36),
                     field_str VARCHAR(255) NOT NULL,
-                    field_int INT(11) NOT NULL,
+                    field_int INT NOT NULL,
                     field_bool BOOL NOT NULL,
                     PRIMARY KEY (uuid),
-                    CONSTRAINT `fk_lwp1_2_root_uuid` FOREIGN KEY (`root`)
-                        REFERENCES `root` (`uuid`)
+                    FOREIGN KEY (root)
+                        REFERENCES root (uuid)
                         ON DELETE RESTRICT
                         ON UPDATE RESTRICT
-                ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+                );
             """,
             """
                 CREATE TABLE IF NOT EXISTS lwp2_1 (
                     uuid CHAR(36) NOT NULL,
                     lwp1_1 CHAR(36) NOT NULL,
                     field_str VARCHAR(255) NOT NULL,
-                    field_int INT(11) NOT NULL,
+                    field_int INT NOT NULL,
                     field_bool BOOL NOT NULL,
                     PRIMARY KEY (uuid),
-                    CONSTRAINT `fk_lwp2_1_lwp1_1_uuid` FOREIGN KEY (`lwp1_1`)
-                        REFERENCES `lwp1_1` (`uuid`)
+                    FOREIGN KEY (lwp1_1)
+                        REFERENCES lwp1_1 (uuid)
                         ON DELETE RESTRICT
                         ON UPDATE RESTRICT
-                ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+                );
             """,
             """
                 CREATE TABLE IF NOT EXISTS lwp2_2 (
                     uuid CHAR(36) NOT NULL,
                     lwp1_1 CHAR(36),
                     field_str VARCHAR(255) NOT NULL,
-                    field_int INT(11) NOT NULL,
+                    field_int INT NOT NULL,
                     field_bool BOOL NOT NULL,
                     PRIMARY KEY (uuid),
-                    CONSTRAINT `fk_lwp2_2_lwp1_1_uuid` FOREIGN KEY (`lwp1_1`)
-                        REFERENCES `lwp1_1` (`uuid`)
+                    FOREIGN KEY (lwp1_1)
+                        REFERENCES lwp1_1 (uuid)
                         ON DELETE RESTRICT
                         ON UPDATE RESTRICT
-                ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+                );
             """,
             """
                 CREATE TABLE IF NOT EXISTS lwp2_3 (
                     uuid CHAR(36) NOT NULL,
                     lwp1_2 CHAR(36) NOT NULL,
                     field_str VARCHAR(255) NOT NULL,
-                    field_int INT(11) NOT NULL,
+                    field_int INT NOT NULL,
                     field_bool BOOL NOT NULL,
                     PRIMARY KEY (uuid),
-                    CONSTRAINT `fk_lwp2_3_lwp1_2_uuid` FOREIGN KEY (`lwp1_2`)
-                        REFERENCES `lwp1_2` (`uuid`)
+                    FOREIGN KEY (lwp1_2)
+                        REFERENCES lwp1_2 (uuid)
                         ON DELETE RESTRICT
                         ON UPDATE RESTRICT
-                ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+                );
             """,
             """
                 CREATE TABLE IF NOT EXISTS lwp2_4 (
                     uuid CHAR(36) NOT NULL,
                     lwp1_2 CHAR(36),
                     field_str VARCHAR(255) NOT NULL,
-                    field_int INT(11) NOT NULL,
+                    field_int INT NOT NULL,
                     field_bool BOOL NOT NULL,
                     PRIMARY KEY (uuid),
-                    CONSTRAINT `fk_lwp2_4_lwp1_2_uuid` FOREIGN KEY (`lwp1_2`)
-                        REFERENCES `lwp1_2` (`uuid`)
+                    FOREIGN KEY (lwp1_2)
+                        REFERENCES lwp1_2 (uuid)
                         ON DELETE RESTRICT
                         ON UPDATE RESTRICT
-                ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+                );
             """,
         ]
 

--- a/restalchemy/tests/functional/migrations/test-batch-migration-9e335f.py
+++ b/restalchemy/tests/functional/migrations/test-batch-migration-9e335f.py
@@ -30,30 +30,30 @@ class MigrationStep(migrations.AbstarctMigrationStep):
     def upgrade(self, session):
         sql_expr_list = [
             """
-                CREATE TABLE `batch_insert` (
-                    `uuid` CHAR(36) NOT NULL,
-                    `foo_field1` INT NOT NULL,
-                    `foo_field2` VARCHAR(255) NOT NULL,
-                PRIMARY KEY (`uuid`),
-                UNIQUE KEY `index2` (`foo_field1`));
+                CREATE TABLE IF NOT EXISTS batch_insert (
+                    uuid CHAR(36) NOT NULL,
+                    foo_field1 INT NOT NULL,
+                    foo_field2 VARCHAR(255) NOT NULL,
+                PRIMARY KEY (uuid),
+                UNIQUE (foo_field1));
             """,
             """
-                CREATE TABLE `batch_delete_one_pk` (
-                    `uuid` CHAR(36) NOT NULL,
-                    `foo_field1` INT NOT NULL,
-                    `foo_field2` VARCHAR(255) NOT NULL,
-                PRIMARY KEY (`uuid`));
+                CREATE TABLE IF NOT EXISTS batch_delete_one_pk (
+                    uuid CHAR(36) NOT NULL,
+                    foo_field1 INT NOT NULL,
+                    foo_field2 VARCHAR(255) NOT NULL,
+                PRIMARY KEY (uuid));
             """,
             """
-                CREATE TABLE `batch_delete_two_pk` (
-                    `uuid` CHAR(36) NOT NULL,
-                    `foo_field1` INT NOT NULL,
-                    `foo_field2` VARCHAR(255) NOT NULL,
-                PRIMARY KEY (`uuid`, `foo_field1`));
+                CREATE TABLE IF NOT EXISTS batch_delete_two_pk (
+                    uuid CHAR(36) NOT NULL,
+                    foo_field1 INT NOT NULL,
+                    foo_field2 VARCHAR(255) NOT NULL,
+                PRIMARY KEY (uuid, foo_field1));
             """,
             """
                 INSERT INTO batch_delete_one_pk (
-                     `uuid`, `foo_field1`, `foo_field2`
+                     uuid, foo_field1, foo_field2
                 ) VALUES (
                     '00000000-0000-0000-0000-000000000000', 0, '0'
                 ), (
@@ -66,7 +66,7 @@ class MigrationStep(migrations.AbstarctMigrationStep):
             """,
             """
                 INSERT INTO batch_delete_two_pk (
-                     `uuid`, `foo_field1`, `foo_field2`
+                     uuid, foo_field1, foo_field2
                 ) VALUES (
                     '00000000-0000-0000-0000-000000000000', 0, '0'
                 ), (

--- a/restalchemy/tests/functional/migrations/test-count-migration-502944.py
+++ b/restalchemy/tests/functional/migrations/test-count-migration-502944.py
@@ -29,25 +29,25 @@ class MigrationStep(migrations.AbstarctMigrationStep):
     def upgrade(self, session):
         sql_expr_list = [
             """
-                CREATE TABLE `test_count` (
-                    `uuid` CHAR(36) NOT NULL,
-                    `foo_field1` INT NOT NULL,
-                    `foo_field2` VARCHAR(255) NOT NULL,
-                PRIMARY KEY (`uuid`));
+                CREATE TABLE test_count (
+                    uuid CHAR(36) NOT NULL,
+                    foo_field1 INT NOT NULL,
+                    foo_field2 VARCHAR(255) NOT NULL,
+                PRIMARY KEY (uuid));
             """,
             """
-                    INSERT INTO test_count (
-                         `uuid`, `foo_field1`, `foo_field2`
-                    ) VALUES (
-                        '00000000-0000-0000-0000-000000000000', 1, 'value1'
-                    ), (
-                        '00000000-0000-0000-0000-000000000001', 2, 'value2'
-                    ), (
-                        '00000000-0000-0000-0000-000000000002', 3, 'value3'
-                    ), (
-                        '00000000-0000-0000-0000-000000000003', 4, 'other1'
-                    )
-                """,
+                INSERT INTO test_count (
+                     uuid, foo_field1, foo_field2
+                ) VALUES (
+                    '00000000-0000-0000-0000-000000000000', 1, 'value1'
+                ), (
+                    '00000000-0000-0000-0000-000000000001', 2, 'value2'
+                ), (
+                    '00000000-0000-0000-0000-000000000002', 3, 'value3'
+                ), (
+                    '00000000-0000-0000-0000-000000000003', 4, 'other1'
+                )
+            """,
         ]
 
         [session.execute(expr) for expr in sql_expr_list]

--- a/restalchemy/tests/unit/storage/sql/dialect/query_builders/test_prefetch_query.py
+++ b/restalchemy/tests/unit/storage/sql/dialect/query_builders/test_prefetch_query.py
@@ -22,6 +22,7 @@ from restalchemy.dm import models
 from restalchemy.dm import properties
 from restalchemy.dm import relationships
 from restalchemy.dm import types
+from restalchemy.tests import fixtures
 from restalchemy.storage.sql.dialect.query_builder import q
 from restalchemy.storage.sql import orm
 
@@ -81,7 +82,10 @@ class MySQLPrefetchQueryBuilderTestCase(unittest.TestCase):
         del self.Q
 
     def test_l1_select(self):
-        query = self.Q.select(ModelWithL1Relationships)
+        query = self.Q.select(
+            model=ModelWithL1Relationships,
+            session=fixtures.SessionFixture(),
+        )
 
         result = query.compile()
 
@@ -103,7 +107,10 @@ class MySQLPrefetchQueryBuilderTestCase(unittest.TestCase):
         )
 
     def test_l1_select_with_filters(self):
-        query = self.Q.select(ModelWithL1Relationships).where(self.flt)
+        query = self.Q.select(
+            model=ModelWithL1Relationships,
+            session=fixtures.SessionFixture(),
+        ).where(self.flt)
 
         result_expression = query.compile()
         result_values = query.values()
@@ -138,7 +145,10 @@ class MySQLPrefetchQueryBuilderTestCase(unittest.TestCase):
         )
 
     def test_select_with_limit(self):
-        query = self.Q.select(ModelWithL1Relationships).limit(100500)
+        query = self.Q.select(
+            model=ModelWithL1Relationships,
+            session=fixtures.SessionFixture(),
+        ).limit(100500)
 
         result_expression = query.compile()
         result_values = query.values()
@@ -163,7 +173,14 @@ class MySQLPrefetchQueryBuilderTestCase(unittest.TestCase):
         self.assertEqual([], result_values)
 
     def test_l1_select_lock_with_filters(self):
-        query = self.Q.select(ModelWithL1Relationships).where(self.flt).for_()
+        query = (
+            self.Q.select(
+                model=ModelWithL1Relationships,
+                session=fixtures.SessionFixture(),
+            )
+            .where(self.flt)
+            .for_()
+        )
 
         result_expression = query.compile()
         result_values = query.values()
@@ -199,7 +216,10 @@ class MySQLPrefetchQueryBuilderTestCase(unittest.TestCase):
         )
 
     def test_l1_select_order_by(self):
-        query = self.Q.select(ModelWithL1Relationships).order_by("uuid")
+        query = self.Q.select(
+            model=ModelWithL1Relationships,
+            session=fixtures.SessionFixture(),
+        ).order_by("uuid")
 
         result_expression = query.compile()
         result_values = query.values()
@@ -225,7 +245,10 @@ class MySQLPrefetchQueryBuilderTestCase(unittest.TestCase):
         self.assertEqual([], result_values)
 
     def test_l2_select(self):
-        result = self.Q.select(ModelWithL2Relationships).compile()
+        result = self.Q.select(
+            model=ModelWithL2Relationships,
+            session=fixtures.SessionFixture(),
+        ).compile()
 
         self.assertEqual(
             "SELECT"
@@ -270,7 +293,10 @@ class MySQLResultParserTestCase(unittest.TestCase):
             "t2_field_str": "FakeStr",
             "t2_uuid": "FakeUUID1",
         }
-        select_clause = q.Q.select(ModelWithL1Relationships)
+        select_clause = q.Q.select(
+            ModelWithL1Relationships,
+            fixtures.SessionFixture(),
+        )
 
         result = select_clause.parse_row(row_from_db)
 

--- a/restalchemy/tests/unit/storage/sql/dialect/query_builders/test_q.py
+++ b/restalchemy/tests/unit/storage/sql/dialect/query_builders/test_q.py
@@ -18,27 +18,47 @@ import unittest
 
 from restalchemy.storage.sql.dialect.query_builder import common
 from restalchemy.storage.sql.dialect.query_builder import q
+from restalchemy.tests import fixtures
 
 
 class TestOrderByValue(unittest.TestCase):
     def setUp(self):
-        self.column = common.Column("1", None)
+        self.column = common.Column(
+            "1",
+            None,
+            fixtures.SessionFixture(),
+        )
 
     def test_empty_type(self):
-        order = q.OrderByValue(self.column)
+        order = q.OrderByValue(
+            self.column,
+            fixtures.SessionFixture(),
+        )
 
         self.assertEqual("`1` ASC", order.compile())
 
     def test_valid_type(self):
-        order = q.OrderByValue(self.column, sort_type="DESC")
+        order = q.OrderByValue(
+            self.column,
+            sort_type="DESC",
+            session=fixtures.SessionFixture(),
+        )
 
         self.assertEqual("`1` DESC", order.compile())
 
     def test_invalid_type(self):
         with self.assertRaises(ValueError):
-            q.OrderByValue(self.column, sort_type="WRONG")
+            q.OrderByValue(
+                self.column,
+                sort_type="WRONG",
+                session=fixtures.SessionFixture(),
+            )
 
     def test_valid_type_lowercase(self):
-        order = q.OrderByValue(self.column, sort_type="desc")
+        order = q.OrderByValue(
+            self.column,
+            sort_type="desc",
+            session=fixtures.SessionFixture(),
+        )
 
         self.assertEqual("`1` DESC", order.compile())

--- a/restalchemy/tests/unit/storage/sql/dialect/query_builders/test_simple_query.py
+++ b/restalchemy/tests/unit/storage/sql/dialect/query_builders/test_simple_query.py
@@ -21,6 +21,7 @@ from restalchemy.dm import models
 from restalchemy.dm import properties
 from restalchemy.dm import types
 from restalchemy.storage.sql.dialect.query_builder import q
+from restalchemy.tests import fixtures
 
 
 class SimpleModel(models.ModelWithUUID):
@@ -51,7 +52,10 @@ class MySQLQueryBuilderTestCase(unittest.TestCase):
         del self.Q
 
     def test_simple_select(self):
-        result = self.Q.select(SimpleModel).compile()
+        result = self.Q.select(
+            model=SimpleModel,
+            session=fixtures.SessionFixture(),
+        ).compile()
 
         self.assertEqual(
             "SELECT"
@@ -65,7 +69,10 @@ class MySQLQueryBuilderTestCase(unittest.TestCase):
         )
 
     def test_select_with_filters(self):
-        query = self.Q.select(SimpleModel).where(self.flt)
+        query = self.Q.select(
+            model=SimpleModel,
+            session=fixtures.SessionFixture(),
+        ).where(self.flt)
 
         result_expression = query.compile()
         result_values = query.values()
@@ -88,7 +95,14 @@ class MySQLQueryBuilderTestCase(unittest.TestCase):
 
     def test_select_two_where_clause(self):
         second_filter = filters.AND({"field_str": filters.EQ("FAKE_STR_TWO")})
-        query = self.Q.select(SimpleModel).where(self.flt).where(second_filter)
+        query = (
+            self.Q.select(
+                model=SimpleModel,
+                session=fixtures.SessionFixture(),
+            )
+            .where(self.flt)
+            .where(second_filter)
+        )
 
         result_expression = query.compile()
         result_values = query.values()
@@ -111,7 +125,14 @@ class MySQLQueryBuilderTestCase(unittest.TestCase):
         self.assertEqual([True, 0, "FAKE_STR", "FAKE_STR_TWO"], result_values)
 
     def test_select_with_filters_and_limit(self):
-        query = self.Q.select(SimpleModel).where(self.flt).limit(2)
+        query = (
+            self.Q.select(
+                model=SimpleModel,
+                session=fixtures.SessionFixture(),
+            )
+            .where(self.flt)
+            .limit(2)
+        )
 
         result_expression = query.compile()
         result_values = query.values()
@@ -134,7 +155,14 @@ class MySQLQueryBuilderTestCase(unittest.TestCase):
         self.assertEqual([True, 0, "FAKE_STR"], result_values)
 
     def test_select_lock_with_filters(self):
-        query = self.Q.select(SimpleModel).where(self.flt).for_()
+        query = (
+            self.Q.select(
+                model=SimpleModel,
+                session=fixtures.SessionFixture(),
+            )
+            .where(self.flt)
+            .for_()
+        )
 
         result_expression = query.compile()
         result_values = query.values()
@@ -157,7 +185,15 @@ class MySQLQueryBuilderTestCase(unittest.TestCase):
         self.assertEqual([True, 0, "FAKE_STR"], result_values)
 
     def test_select_lock_with_filters_and_limit(self):
-        query = self.Q.select(SimpleModel).where(self.flt).for_().limit(2)
+        query = (
+            self.Q.select(
+                model=SimpleModel,
+                session=fixtures.SessionFixture(),
+            )
+            .where(self.flt)
+            .for_()
+            .limit(2)
+        )
 
         result_expression = query.compile()
         result_values = query.values()
@@ -182,7 +218,12 @@ class MySQLQueryBuilderTestCase(unittest.TestCase):
 
     def test_select_order_by_with_filters(self):
         query = (
-            self.Q.select(SimpleModel).where(self.flt).order_by("field_str")
+            self.Q.select(
+                model=SimpleModel,
+                session=fixtures.SessionFixture(),
+            )
+            .where(self.flt)
+            .order_by("field_str")
         )
         query = query.order_by("field_int", "DESC")
 
@@ -218,7 +259,10 @@ class MySQLResultParserTestCase(unittest.TestCase):
             "t1_field_str": "FakeStr",
             "t1_uuid": "FakeUUID",
         }
-        select_clause = q.Q.select(SimpleModel)
+        select_clause = q.Q.select(
+            SimpleModel,
+            session=fixtures.SessionFixture(),
+        )
 
         result = select_clause.parse_row(row_from_db)
 

--- a/restalchemy/tests/unit/storage/sql/test_filters.py
+++ b/restalchemy/tests/unit/storage/sql/test_filters.py
@@ -28,6 +28,7 @@ from restalchemy.storage.sql import filters
 from restalchemy.storage.sql import orm
 from restalchemy.tests.unit import base
 from restalchemy.tests.unit.storage.sql import common
+from restalchemy.tests import fixtures
 
 
 TEST_NAME = "FAKE_NAME"
@@ -53,7 +54,10 @@ class EQTestCase(base.BaseTestCase):
 
     def setUp(self):
         self._expr = filters.EQ(
-            column=TEST_NAME, value_type=common.AsIsType(), value=TEST_VALUE
+            column=TEST_NAME,
+            value_type=common.AsIsType(),
+            value=TEST_VALUE,
+            session=fixtures.SessionFixture(),
         )
 
     def test_construct_expression(self):
@@ -70,7 +74,10 @@ class NETestCase(base.BaseTestCase):
 
     def setUp(self):
         self._expr = filters.NE(
-            column=TEST_NAME, value_type=common.AsIsType(), value=TEST_VALUE
+            column=TEST_NAME,
+            value_type=common.AsIsType(),
+            value=TEST_VALUE,
+            session=fixtures.SessionFixture(),
         )
 
     def test_construct_expression(self):
@@ -87,7 +94,10 @@ class GTTestCase(base.BaseTestCase):
 
     def setUp(self):
         self._expr = filters.GT(
-            column=TEST_NAME, value_type=common.AsIsType(), value=TEST_VALUE
+            column=TEST_NAME,
+            value_type=common.AsIsType(),
+            value=TEST_VALUE,
+            session=fixtures.SessionFixture(),
         )
 
     def test_construct_expression(self):
@@ -104,7 +114,10 @@ class GETestCase(base.BaseTestCase):
 
     def setUp(self):
         self._expr = filters.GE(
-            column=TEST_NAME, value_type=common.AsIsType(), value=TEST_VALUE
+            column=TEST_NAME,
+            value_type=common.AsIsType(),
+            value=TEST_VALUE,
+            session=fixtures.SessionFixture(),
         )
 
     def test_construct_expression(self):
@@ -121,7 +134,10 @@ class LTTestCase(base.BaseTestCase):
 
     def setUp(self):
         self._expr = filters.LT(
-            column=TEST_NAME, value_type=common.AsIsType(), value=TEST_VALUE
+            column=TEST_NAME,
+            value_type=common.AsIsType(),
+            value=TEST_VALUE,
+            session=fixtures.SessionFixture(),
         )
 
     def test_construct_expression(self):
@@ -138,7 +154,10 @@ class LETestCase(base.BaseTestCase):
 
     def setUp(self):
         self._expr = filters.LE(
-            column=TEST_NAME, value_type=common.AsIsType(), value=TEST_VALUE
+            column=TEST_NAME,
+            value_type=common.AsIsType(),
+            value=TEST_VALUE,
+            session=fixtures.SessionFixture(),
         )
 
     def test_construct_expression(self):
@@ -156,10 +175,11 @@ class InTestCase(base.BaseTestCase):
     TEST_LIST_VALUES = [1, 2, 3]
 
     def setUp(self):
-        self._expr = filters.In(
+        self._expr = filters.MySqlIn(
             column=TEST_NAME,
             value_type=common.AsIsType(),
             value=self.TEST_LIST_VALUES,
+            session=fixtures.SessionFixture(),
         )
 
     def test_construct_expression(self):
@@ -177,10 +197,11 @@ class NotInTestCase(base.BaseTestCase):
     TEST_LIST_VALUES = [1, 2, 3]
 
     def setUp(self):
-        self._expr = filters.NotIn(
+        self._expr = filters.MySqlNotIn(
             column=TEST_NAME,
             value_type=common.AsIsType(),
             value=self.TEST_LIST_VALUES,
+            session=fixtures.SessionFixture(),
         )
 
     def test_construct_expression(self):
@@ -196,8 +217,11 @@ class NotInTestCase(base.BaseTestCase):
 class InEmptyListTestCase(base.BaseTestCase):
 
     def setUp(self):
-        self._expr = filters.In(
-            column=TEST_NAME, value_type=common.AsIsType(), value=[]
+        self._expr = filters.MySqlIn(
+            column=TEST_NAME,
+            value_type=common.AsIsType(),
+            value=[],
+            session=fixtures.SessionFixture(),
         )
 
     def test_construct_expression(self):
@@ -214,7 +238,10 @@ class IsTestCase(base.BaseTestCase):
 
     def setUp(self):
         self._expr = filters.Is(
-            column=TEST_NAME, value_type=common.AsIsType(), value=TEST_VALUE
+            column=TEST_NAME,
+            value_type=common.AsIsType(),
+            value=TEST_VALUE,
+            session=fixtures.SessionFixture(),
         )
 
     def test_construct_expression(self):
@@ -231,7 +258,10 @@ class IsNotTestCase(base.BaseTestCase):
 
     def setUp(self):
         self._expr = filters.IsNot(
-            column=TEST_NAME, value_type=common.AsIsType(), value=TEST_VALUE
+            column=TEST_NAME,
+            value_type=common.AsIsType(),
+            value=TEST_VALUE,
+            session=fixtures.SessionFixture(),
         )
 
     def test_construct_expression(self):
@@ -248,7 +278,10 @@ class LikeTestCase(base.BaseTestCase):
 
     def setUp(self):
         self._expr = filters.Like(
-            column=TEST_NAME, value_type=common.AsIsType(), value=TEST_VALUE
+            column=TEST_NAME,
+            value_type=common.AsIsType(),
+            value=TEST_VALUE,
+            session=fixtures.SessionFixture(),
         )
 
     def test_construct_expression(self):
@@ -265,7 +298,10 @@ class NotLikeTestCase(base.BaseTestCase):
 
     def setUp(self):
         self._expr = filters.NotLike(
-            column=TEST_NAME, value_type=common.AsIsType(), value=TEST_VALUE
+            column=TEST_NAME,
+            value_type=common.AsIsType(),
+            value=TEST_VALUE,
+            session=fixtures.SessionFixture(),
         )
 
     def test_construct_expression(self):
@@ -286,7 +322,11 @@ class ConvertFiltersTestCase(base.BaseTestCase):
         d["name2"] = dm_filters.EQ(2)
         filter_list = dm_filters.AND(d)
 
-        processed = filters.convert_filters(BaseModel, filter_list)
+        processed = filters.convert_filters(
+            BaseModel,
+            filter_list,
+            session=fixtures.SessionFixture(),
+        )
 
         self.assertEqual(
             "(`name1` = %s AND `name2` = %s)", processed.construct_expression()
@@ -298,7 +338,11 @@ class ConvertFiltersTestCase(base.BaseTestCase):
             {"name1": dm_filters.EQ(1)}, {"name2": dm_filters.EQ(2)}
         )
 
-        processed = filters.convert_filters(BaseModel, filter_list)
+        processed = filters.convert_filters(
+            BaseModel,
+            filter_list,
+            session=fixtures.SessionFixture(),
+        )
 
         self.assertEqual(
             "(`name1` = %s AND `name2` = %s)", processed.construct_expression()
@@ -313,7 +357,11 @@ class ConvertFiltersTestCase(base.BaseTestCase):
             dm_filters.AND(d), dm_filters.AND({"name2": dm_filters.EQ(2)})
         )
 
-        processed = filters.convert_filters(BaseModel, filter_list)
+        processed = filters.convert_filters(
+            BaseModel,
+            filter_list,
+            session=fixtures.SessionFixture(),
+        )
 
         self.assertEqual(
             "((`name1` = %s AND `name2` = %s) OR (`name2` = %s))",
@@ -327,7 +375,11 @@ class ConvertFiltersTestCase(base.BaseTestCase):
         d["name2"] = dm_filters.EQ(2)
         filter_list = d
 
-        processed = filters.convert_filters(BaseModel, filter_list)
+        processed = filters.convert_filters(
+            BaseModel,
+            filter_list,
+            session=fixtures.SessionFixture(),
+        )
 
         self.assertEqual(
             "(`name1` = %s AND `name2` = %s)", processed.construct_expression()
@@ -340,7 +392,11 @@ class ConvertFiltersTestCase(base.BaseTestCase):
         d.add("name1", dm_filters.EQ(1))
         filter_list = d
 
-        processed = filters.convert_filters(BaseModel, filter_list)
+        processed = filters.convert_filters(
+            BaseModel,
+            filter_list,
+            session=fixtures.SessionFixture(),
+        )
 
         self.assertEqual(
             "(`name1` = %s AND `name1` = %s)", processed.construct_expression()
@@ -351,7 +407,11 @@ class ConvertFiltersTestCase(base.BaseTestCase):
         model = BaseModelWithUUID(name1=1, name2=2, uuid=TEST_UUID)
         filter_list = {"parent": dm_filters.EQ(model)}
 
-        processed = filters.convert_filters(BaseModelWithRelation, filter_list)
+        processed = filters.convert_filters(
+            BaseModelWithRelation,
+            filter_list,
+            session=fixtures.SessionFixture(),
+        )
 
         self.assertEqual("(`parent` = %s)", processed.construct_expression())
         self.assertEqual([str(TEST_UUID)], processed.value)
@@ -359,7 +419,11 @@ class ConvertFiltersTestCase(base.BaseTestCase):
     def test_convert_filters_new_relationship_by_id(self):
         filter_list = {"parent": dm_filters.EQ(TEST_UUID)}
 
-        processed = filters.convert_filters(BaseModelWithRelation, filter_list)
+        processed = filters.convert_filters(
+            BaseModelWithRelation,
+            filter_list,
+            session=fixtures.SessionFixture(),
+        )
 
         self.assertEqual("(`parent` = %s)", processed.construct_expression())
         self.assertEqual([str(TEST_UUID)], processed.value)

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ passenv =
   functional: MYSQL_DATABASE
   functional: DATABASE_URI
 commands =
-  coverage run -p -m pytest {posargs} --timer-top-n=10 {env:TEST_PATH}
+  coverage run -p -m pytest -x {posargs} --timer-top-n=10 {env:TEST_PATH}
 
 
 [testenv:begin]


### PR DESCRIPTION
Added functionality to work with PostgreSQL databases, enhancing storage capabilities.

- Updated `engines.engine_factory` configuration to support PostgreSQL
- Provided example models and CRUD operations demonstrating PostgreSQL usage
- Added comprehensive examples for:
  - Model creation and persistence
  - Querying and filtering
  - Updating and deleting records

Example of configuration and basic usage:

```python
engines.engine_factory.configure_factory(
    db_url="postgresql://postgres:password@127.0.0.1:5432/ra_tests"
)

class FooModel(models.ModelWithUUID, orm.SQLStorableMixin):
    __tablename__ = "foos"
    foo_field1 = properties.property(types.Integer(), required=True)
    foo_field2 = properties.property(types.String(), default="foo_str")

foo1 = FooModel(foo_field1=10)
foo1.save()

print(list(FooModel.objects.get_all()))
```

This enhances the ability to use different database systems with the existing ORM functionality.