### PR TITLE
Add Email data type with validation using email-validator

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ oslo.config>=3.22.0,<8  # Apache-2.0
 PyYAML>=6.0  # MIT
 netaddr>=0.7.18  # BSD
 psycopg[binary,pool]>=3.2.4,<4.0.0  # GNU Lesser General Public License v3 (LGPLv3)
+email-validator>=2.2.0,<3.0.0  # Free, The Unlicense

--- a/restalchemy/tests/unit/dm/test_types.py
+++ b/restalchemy/tests/unit/dm/test_types.py
@@ -139,6 +139,54 @@ class UUIDTestCase(base.BaseTestCase):
         )
 
 
+class EmailTestCase(base.BaseTestCase):
+
+    def setUp(self):
+        super(EmailTestCase, self).setUp()
+        self.test_instance1 = types.Email()
+        self.test_instance2 = types.Email(5, 10)
+        self.test_instance3 = types.Email(5, 100, check_deliverability=True)
+
+    def test_correct_email_value(self):
+        CORRECT_EMAIL = "eugene@frolov.net.ru"
+
+        self.assertTrue(self.test_instance1.validate(CORRECT_EMAIL))
+
+    def test_correct_short_email_value(self):
+        CORRECT_EMAIL = "a@b.c"
+
+        self.assertTrue(self.test_instance1.validate(CORRECT_EMAIL))
+
+    def test_incorrect_email_value(self):
+        INCORRECT_EMAIL = "eugene@frolov"
+
+        self.assertFalse(self.test_instance1.validate(INCORRECT_EMAIL))
+
+    def test_incorrect_very_short_email_value(self):
+        INCORECT_EMAIL = "x@x"
+
+        self.assertFalse(self.test_instance1.validate(INCORECT_EMAIL))
+
+    def test_deliverability_email_value(self):
+        CORRECT_DELIVERABLE_EMAIL = "eugene@gmail.com"
+
+        self.assertTrue(
+            self.test_instance3.validate(CORRECT_DELIVERABLE_EMAIL)
+        )
+
+    def test_email_to_very_long_value(self):
+        INCORRECT_EMAIL = "eugene@gmail.com"
+
+        self.assertFalse(self.test_instance2.validate(INCORRECT_EMAIL))
+
+    def test_non_deliverability_email_value(self):
+        CORRECT_NOT_DELIVERABLE_EMAIL = "eugene@frolov.incorrectzone"
+
+        self.assertFalse(
+            self.test_instance3.validate(CORRECT_NOT_DELIVERABLE_EMAIL)
+        )
+
+
 class StringTestCase(base.BaseTestCase):
 
     FAKE_STRING1 = "fake!!!"


### PR DESCRIPTION
- Add email-validator>=2.2.0 dependency to requirements.txt
- Implement Email type inheriting from String:
  * Default length constraints: 5-254 chars (e.g. "a@b.c" to min RFC length)
  * Email format validation using email-validator (e.g. "user@example.com")
  * Optional deliverability checking for domain verification (check_deliverability=True)
  * OpenAPI format: "email" (generates "format: email" in schema)
  * Example usage:
    ```python
    from restalchemy.dm import models
    from restalchemy.dm import properties
    from restalchemy.dm import types

    types.Email().validate("a@b.c")  #True. basic email validation
    types.Email(check_deliverability=True).validate("a@b.c")  # False. verify domain MX records

    class User(models.ModelWithUUID):
        email = properties.property(
            types.Email(max_length=128),
            required=True,
        )

    User(email="a@b.c")  # correct
    User(email="asdasddas") # incorrect, validation error
    ```

- Enhance String type to support kwargs for extended configurations:
  * Allows setting openapi_format/type for subclasses (used for Email format)
  * Example: String(openapi_format="password") for secret fields