### PR TITLE
Introduce models with most frequent fields: 

### DIFF
--- a/restalchemy/dm/models.py
+++ b/restalchemy/dm/models.py
@@ -16,6 +16,7 @@
 
 import abc
 import copy
+import datetime
 import uuid
 
 from collections import abc as collections_abc
@@ -281,3 +282,39 @@ class CustomPropertiesMixin(object):
                 )
                 % (name, should_be, value)
             )
+
+
+class ModelWithTimestamp(Model):
+
+    created_at = properties.property(
+        types.UTCDateTime(),
+        required=True,
+        read_only=True,
+        default=lambda: datetime.datetime.now(datetime.timezone.utc),
+    )
+    updated_at = properties.property(
+        types.UTCDateTime(),
+        required=True,
+        read_only=True,
+        default=lambda: datetime.datetime.now(datetime.timezone.utc),
+    )
+
+    def update(self, session=None, force=False, *args, **kwargs):
+        if self.is_dirty() or force:
+            self.properties["updated_at"].set_value_force(
+                datetime.datetime.now(datetime.timezone.utc)
+            )
+        super().update(session=session, force=force, *args, **kwargs)
+
+
+class ModelWithProject(Model):
+
+    project_id = properties.property(
+        types.UUID(), required=True, read_only=True
+    )
+
+
+class ModelWithNameDesc(Model):
+
+    name = properties.property(types.String(max_length=255), default="")
+    description = properties.property(types.String(max_length=255), default="")


### PR DESCRIPTION
1. **ModelWithTimestamp**: This model includes `created_at` and `updated_at` fields which are automatically set to the current UTC time when a new instance is created or an existing one is updated. The `update` method ensures that `updated_at` is always updated to the current time during updates.

2. **ModelWithProject**: This model has an `project_id` field, which must be provided and cannot be changed after creation.

3. **ModelWithNameDesc**: This model includes two fields: `name` and `description`, both of which are strings with maximum lengths of 255 characters and default values of empty strings.

These changes improve the modularity of model classes by encapsulating common behaviors such as timestamping, tenant management, and name/description fields. This enhances maintainability and reduces redundancy across different models.