### PR TITLE
Add new controller and refactor route listing logic into a base controller

### DIFF
--- a/restalchemy/tests/functional/restapi/ra_based/microservice/controllers.py
+++ b/restalchemy/tests/functional/restapi/ra_based/microservice/controllers.py
@@ -148,10 +148,9 @@ class VMController(controllers.BaseResourceControllerPaginated):
         return {"state": resource.state}
 
 
-class V1Controller(controllers.Controller):
+class V1Controller(controllers.RoutesListController):
 
-    def filter(self, filters):
-        return ["vms"]
+    __TARGET_PATH__ = "/v1"
 
 
 class NotImplementedMethodsController(controllers.Controller):

--- a/restalchemy/tests/functional/restapi/ra_based/test_resources.py
+++ b/restalchemy/tests/functional/restapi/ra_based/test_resources.py
@@ -196,7 +196,7 @@ class TestVersionsResourceTestCase(BaseResourceTestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), ["vms"])
+        self.assertEqual(response.json(), ["notimplementedmethods", "vms"])
 
 
 class TestVMResourceTestCase(BaseResourceTestCase):


### PR DESCRIPTION
**Changes:**
- Introduced `RoutesListController` base class with common route filtering functionality
  - Implements `_get_target_route` method to find nested routes by path
  - Provides default `filter()` implementation that returns collection routes from target path
- Modified `RootController` to inherit from `RoutesListController`
  - Removed custom filter implementation as it's now handled by base class
- Updated `V1Controller` in tests to use new base controller
  - Replaced hardcoded filter method with `__TARGET_PATH__ = "/v1"` configuration
  - Now automatically detects collection routes under `/v1` path

**Test Updates:**
- Modified `TestVersionsResourceTestCase` expectations
  - Updated assertion to expect both `["notimplementedmethods", "vms"]` instead of just `["vms"]`
  - Verifies that new route detection logic correctly identifies all collection routes

**Implementation Details:**
- Uses `__TARGET_PATH__` attribute to determine root path for route scanning
- Filters routes using `is_collection_route()` check through request context
- Enables consistent route discovery across different API versions/endpoints