### PR TITLE
register_common_db_opts: use register_cli_opts

### DIFF
--- a/restalchemy/common/config_opts.py
+++ b/restalchemy/common/config_opts.py
@@ -58,7 +58,7 @@ def register_common_db_opts(
         ),
     ]
 
-    conf.register_opts(db_opt, group=config_section)
+    conf.register_cli_opts(db_opt, group=config_section)
 
 
 def register_posgresql_db_opts(


### PR DESCRIPTION
Otherwise, ra-apply-migration and other tools
won't work with CLI arguments for DB.