### PR TITLE
Fix cached queries

### DIFF
--- a/restalchemy/storage/sql/sessions.py
+++ b/restalchemy/storage/sql/sessions.py
@@ -37,17 +37,23 @@ class SessionQueryCache(object):
         self._session = session
         self.__query_cache = {}
 
-    @staticmethod
     def _get_hash(
-        engine, table, filters, limit=None, order_by=None, locked=False
+        self, engine, table, filters, limit=None, order_by=None, locked=False
     ):
-        query = engine.dialect.select(table, filters, limit, order_by, locked)
+        query = engine.dialect.select(
+            table=table,
+            filters=filters,
+            limit=limit,
+            order_by=order_by,
+            session=self._session,
+            locked=locked,
+        )
         values = query.get_values()
         statement = query.get_statement()
         return hash(tuple([statement] + values))
 
-    @staticmethod
     def _get_hash_by_query(
+        self,
         engine,
         table,
         where_conditions,
@@ -62,6 +68,7 @@ class SessionQueryCache(object):
             where_values=where_values,
             limit=limit,
             order_by=order_by,
+            session=self._session,
             locked=locked,
         )
         values = query.get_values()


### PR DESCRIPTION
After Postgresql support patch we had wrong arguments, which produced this traceback:

```
restalchemy/storage/base.py:93:
restalchemy/storage/sql/orm.py:54: in get_all
    return s.cache.get_all(
restalchemy/storage/sql/sessions.py:80: in get_all
    query_hash = self._get_hash(engine, table, filters, limit, locked)
restalchemy/storage/sql/sessions.py:46: in _get_hash
    statement = query.get_statement()
restalchemy/storage/sql/dialect/base.py:675: in get_statement
    ", ".join(self._table.get_escaped_column_names(self._session)),

self = <restalchemy.storage.sql.tables.SQLTable object at 0x7f6f2f377890>, session = 2, with_pk = True, do_sort = True

    def get_escaped_column_names(self, session, with_pk=True, do_sort=True):
        return [
>           session.engine.escape(column_name)
            for column_name in self.get_column_names(
                session=session,
                with_pk=with_pk,
                do_sort=do_sort,
            )
        ]
E       AttributeError: 'int' object has no attribute 'engine'
```

`session=2` was actually unnamed `limit=2`.

Add basic test cases for cache requests.