### PR TITLE
Fix for IS and IS NOT filters in PG dialect

### DIFF
--- a/restalchemy/storage/sql/filters.py
+++ b/restalchemy/storage/sql/filters.py
@@ -134,6 +134,18 @@ class PostgreSqlNotIn(In):
         return f"{self.column} != ANY(%s)"
 
 
+class PostgreSqlIs(Is):
+
+    def construct_expression(self):
+        return f"{self.column} IS NOT DISTINCT FROM (%s)"
+
+
+class PostgreSqlIsNot(IsNot):
+
+    def construct_expression(self):
+        return f"{self.column} IS DISTINCT FROM (%s)"
+
+
 class Like(AbstractClause):
 
     def construct_expression(self):
@@ -227,8 +239,8 @@ FILTER_MAPPING = {
         filters.GE: GE,
         filters.LE: LE,
         filters.LT: LT,
-        filters.Is: Is,
-        filters.IsNot: IsNot,
+        filters.Is: PostgreSqlIs,
+        filters.IsNot: PostgreSqlIsNot,
         filters.In: PostgreSqlIn,
         filters.NotIn: PostgreSqlNotIn,
         filters.Like: Like,

--- a/restalchemy/tests/unit/storage/sql/test_filters.py
+++ b/restalchemy/tests/unit/storage/sql/test_filters.py
@@ -274,6 +274,46 @@ class IsNotTestCase(base.BaseTestCase):
         self.assertEqual(self._expr.value, TEST_VALUE)
 
 
+class IsPgTestCase(base.BaseTestCase):
+
+    def setUp(self):
+        self._expr = filters.PostgreSqlIs(
+            column=TEST_NAME,
+            value_type=common.AsIsType(),
+            value=TEST_VALUE,
+            session=fixtures.SessionFixture(),
+        )
+
+    def test_construct_expression(self):
+
+        result = self._expr.construct_expression()
+
+        self.assertEqual(TEST_NAME + " IS NOT DISTINCT FROM (%s)", result)
+
+    def test_value_property(self):
+        self.assertEqual(self._expr.value, TEST_VALUE)
+
+
+class IsNotPgTestCase(base.BaseTestCase):
+
+    def setUp(self):
+        self._expr = filters.PostgreSqlIsNot(
+            column=TEST_NAME,
+            value_type=common.AsIsType(),
+            value=TEST_VALUE,
+            session=fixtures.SessionFixture(),
+        )
+
+    def test_construct_expression(self):
+
+        result = self._expr.construct_expression()
+
+        self.assertEqual(TEST_NAME + " IS DISTINCT FROM (%s)", result)
+
+    def test_value_property(self):
+        self.assertEqual(self._expr.value, TEST_VALUE)
+
+
 class LikeTestCase(base.BaseTestCase):
 
     def setUp(self):


### PR DESCRIPTION
It's turned out we cannot use `IS` and `IS NOT` filters in `psycopg` since:
- https://www.psycopg.org/psycopg3/docs/basic/from_pg2.html#you-cannot-use-is-s
- https://github.com/psycopg/psycopg/discussions/582

This change adds correct filters that acts like  `IS` and `IS NOT`in mysql.