### PR TITLE
Add UTCDateTimeZ Type and Update Tests

### DIFF
--- a/restalchemy/dm/models.py
+++ b/restalchemy/dm/models.py
@@ -287,13 +287,13 @@ class CustomPropertiesMixin(object):
 class ModelWithTimestamp(Model):
 
     created_at = properties.property(
-        types.UTCDateTime(),
+        types.UTCDateTimeZ(),
         required=True,
         read_only=True,
         default=lambda: datetime.datetime.now(datetime.timezone.utc),
     )
     updated_at = properties.property(
-        types.UTCDateTime(),
+        types.UTCDateTimeZ(),
         required=True,
         read_only=True,
         default=lambda: datetime.datetime.now(datetime.timezone.utc),

--- a/restalchemy/tests/functional/restapi/ra_based/microservice/models.py
+++ b/restalchemy/tests/functional/restapi/ra_based/microservice/models.py
@@ -35,8 +35,8 @@ class VM(models.ModelWithUUID):
         types.Enum(["active", "disabled"]), default="active", required=True
     )
     created = properties.property(
-        types.UTCDateTime(),
-        default=lambda: types.DEFAULT_DATE,
+        types.UTCDateTimeZ(),
+        default=lambda: types.DEFAULT_DATE_Z,
     )
     updated = properties.property(
         types.UTCDateTime(),

--- a/restalchemy/tests/unit/dm/test_types.py
+++ b/restalchemy/tests/unit/dm/test_types.py
@@ -733,6 +733,49 @@ class UTCDateTimeTestCase(base.BaseTestCase):
         self.assertEqual(result, dt)
 
 
+class UTCDateTimeZTestCase(base.BaseTestCase):
+
+    def setUp(self):
+        super(UTCDateTimeZTestCase, self).setUp()
+
+        self.test_instance = types.UTCDateTimeZ()
+
+    def test_validate_correct_value_with_explicit_utc_tz(self):
+        self.assertTrue(
+            self.test_instance.validate(
+                datetime.datetime.now(datetime.timezone.utc)
+            )
+        )
+
+    def test_validate_incorrect_value_wo_tz(self):
+        self.assertFalse(self.test_instance.validate(datetime.datetime.now()))
+
+    def test_validate_from_simple_type_wo_tz(self):
+        dt = datetime.datetime(2020, 3, 13, 11, 3, 25)
+        expected = "2020-03-13 11:03:25.000000"
+
+        result = types.UTCDateTimeZ().from_simple_type(dt)
+
+        self.assertEqual(result, dt.replace(tzinfo=datetime.timezone.utc))
+        self.assertIsNone(dt.tzinfo)
+        self.assertEqual(result.tzinfo, datetime.timezone.utc)
+
+    def test_validate_from_simple_type_with_tz(self):
+        dtz = datetime.datetime.fromisoformat("2020-03-13T11:03:25+03:00")
+        expected_utc = "2020-03-13 08:03:25.000000"
+
+        result = types.UTCDateTimeZ().from_simple_type(dtz)
+
+        self.assertEqual(
+            dtz.tzinfo, datetime.timezone(datetime.timedelta(seconds=10800))
+        )
+        self.assertEqual(result.tzinfo, datetime.timezone.utc)
+        self.assertEqual(result, dtz.astimezone(datetime.timezone.utc))
+        self.assertEqual(
+            types.UTCDateTimeZ().to_simple_type(result), expected_utc
+        )
+
+
 class EnumTestCase(base.BaseTestCase):
 
     def setUp(self):

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
-coverage>=3.6,<6  # Apache-2.0
+coverage>=7.0.0,<8.0.0  # Apache-2.0
 flake8>=6.1.0  # MIT License (MIT)
 mock>=1.0.1,<3.0.5  # BSD
 urllib3>=1.26.19,<2.0.0  # MIT
-pytest>=8.0.0  # MIT License (MIT)
-pytest-timer==0.0.11 # MIT License (MIT)
+pytest>=8.0.0,<9.0.0  # MIT License (MIT)
+pytest-timer>=1.0.0,<2.0.0  # MIT License (MIT)


### PR DESCRIPTION
This commit introduces a new `UTCDateTimeZ` class, which extends the existing `UTCDateTime` class. The new class ensures that datetime values explicitly include the UTC timezone information. Additionally, the commit updates the relevant test cases and modifies the `created` property in the `VM` model to use the new `UTCDateTimeZ` type.

- **`UTCDateTimeZ` class**:
  - Extends `UTCDateTime` to enforce UTC timezone validation.
  - Implements `validate` method to check if the datetime object has the UTC timezone.
  - Overrides `from_simple_type` to ensure the returned datetime object includes the UTC timezone.