### PR TITLE
Update UUID regex pattern to support uppercase and improve formatting

### DIFF
--- a/restalchemy/dm/types.py
+++ b/restalchemy/dm/types.py
@@ -29,7 +29,17 @@ import email_validator
 
 INFINITY = float("inf")
 INFINITI = INFINITY  # TODO(d.burmistrov): remove this hack
-UUID_RE_TEMPLATE = r"[a-f0-9]{8,8}-([a-f0-9]{4,4}-){3,3}[a-f0-9]{12,12}"
+UUID_RE_TEMPLATE = (
+    r"[0-9a-fA-F]{8}"
+    r"-"
+    r"[0-9a-fA-F]{4}"
+    r"-"
+    r"[0-9a-fA-F]{4}"
+    r"-"
+    r"[0-9a-fA-F]{4}"
+    r"-"
+    r"[0-9a-fA-F]{12}"
+)
 
 # Copy-paste from validators library because RA must support python 2.7
 # and support cyrillic domain names. The validators library is located:


### PR DESCRIPTION
- **Modify UUID regular expression** to accept both lowercase and uppercase hexadecimal digits (0-9, a-f, A-F), aligning with RFC 4122 specifications which allow case insensitivity.
- **Adjust segment quantifiers** to use concise syntax (e.g., `{8}` instead of `{8,8}`) while maintaining the correct UUID structure (8-4-4-4-12 characters).
- **Fix potential validation issues** where uppercase UUIDs were previously not recognized due to case-sensitive matching.

This change ensures compatibility with UUIDs generated in uppercase format and enhances code maintainability through clearer regex formatting.