### PR TITLE
Refactor RESTService Initialization and WSGI Application Setup

### DIFF
--- a/restalchemy/tests/functional/restapi/ra_based/test_resources.py
+++ b/restalchemy/tests/functional/restapi/ra_based/test_resources.py
@@ -40,7 +40,9 @@ from restalchemy.tests.functional import base
 from restalchemy.tests.functional.restapi.ra_based.microservice import (
     storable_models as models,
 )
+from restalchemy.tests.functional.restapi.ra_based.microservice import routes
 from restalchemy.tests.functional.restapi.ra_based.microservice import service
+
 
 TEMPL_SERVICE_ENDPOINT = utils.lastslash("http://127.0.0.1:%s/")
 TEMPL_ROOT_COLLECTION_ENDPOINT = TEMPL_SERVICE_ENDPOINT
@@ -131,7 +133,9 @@ class BaseResourceTestCase(base.BaseWithDbMigrationsTestCase):
         self.service_port = self.find_free_port()
         url = parse.urlparse(self.get_endpoint(TEMPL_SERVICE_ENDPOINT))
         self._service = service.RESTService(
-            bind_host=url.hostname, bind_port=url.port
+            bind_host=url.hostname,
+            bind_port=url.port,
+            app_root=service.build_wsgi_application(app_root=routes.Root),
         )
         self._service.start()
 


### PR DESCRIPTION
- **Refactored `RESTService` class**:
  - Removed hardcoded default values for `bind_host` and `bind_port` in `__init__`.
  - Added `service_port` and `service_host` properties for better access to service configuration.
  - Simplified server creation by directly passing `app_root` to `simple_server.make_server`.

- **Extracted WSGI application creation** into `build_wsgi_application` function:
  - Centralized OpenAPI configuration and middleware setup.
  - Improved separation of concerns by decoupling application logic from server initialization.

- **Updated entry point and test setup**:
  - Modified `main()` to explicitly specify `bind_host="0.0.0.0"` and `bind_port=8000`.
  - Adjusted test suite in `test_resources.py` to use `build_wsgi_application` when initializing `RESTService`.