### PR TITLE
Return 400 HTTP code on unknown field from requests on unpack + Use pytest-cov instead of coverity

### DIFF
--- a/restalchemy/api/packers.py
+++ b/restalchemy/api/packers.py
@@ -99,7 +99,9 @@ class BaseResourcePacker(object):
                 result[name] = self._parse_value(api_name, prop_value, prop)
 
         if len(value) > 0:
-            raise TypeError("%s is not compatible with %s" % (value, self._rt))
+            raise exceptions.ValidationPropertyIncompatibleError(
+                val=value, model=self._rt.get_model().__name__
+            )
 
         return result
 

--- a/restalchemy/common/exceptions.py
+++ b/restalchemy/common/exceptions.py
@@ -209,6 +209,11 @@ class ValidationPropertyPrivateError(ValidationErrorException):
     message = "Property %(property)s is private"
 
 
+class ValidationPropertyIncompatibleError(ValidationErrorException):
+
+    message = "%(val)s is not compatible with model %(model)s"
+
+
 class NotEqualUuidException(RestAlchemyException):
 
     message = (

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
-coverage>=7.0.0,<8.0.0  # Apache-2.0
 flake8>=6.1.0  # MIT License (MIT)
 mock>=1.0.1,<3.0.5  # BSD
 urllib3>=1.26.19,<2.0.0  # MIT
 pytest>=8.0.0,<9.0.0  # MIT License (MIT)
 pytest-timer>=1.0.0,<2.0.0  # MIT License (MIT)
+pytest-cov>=5.0.0,<7.0.0  # MIT License (MIT)

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ passenv =
   functional: MYSQL_DATABASE
   functional: DATABASE_URI
 commands =
-  coverage run -p -m pytest -x {posargs} --timer-top-n=10 {env:TEST_PATH}
+  pytest --cov={env:PACKAGE_NAME} {posargs} --timer-top-n=10 {env:TEST_PATH}
 
 
 [testenv:begin]
@@ -39,19 +39,9 @@ commands =
   coverage report --skip-covered
 
 
-[testenv:cover]
-envdir = {toxworkdir}/cover
-passenv = DATABASE_URI
-setenv = DATABASE_URI={env:DATABASE_URI:mysql://root:@localhost:3306/radatabase}
-commands =
-  coverage erase
-  coverage run -m pytest {posargs} --timer-top-n=10 {env:PACKAGE_NAME}/tests
-  coverage html -d cover
-  coverage report --skip-covered
-
-
 [testenv:venv]
 commands = {posargs}
+
 
 [testenv:develop]
 deps = -r{toxinidir}/requirements.txt


### PR DESCRIPTION
It gives pleasant stats on every run,
and don't pollute your FS with
`.coverage*` files.