### PR TITLE
Extended network types with IPRange type

### DIFF
--- a/restalchemy/dm/types_network.py
+++ b/restalchemy/dm/types_network.py
@@ -172,3 +172,29 @@ class Hostname(types.BaseCompiledRegExpTypeFromAttr):
             )
         )
         super(Hostname, self).__init__(**kwargs)
+
+
+class IPRange(types.BaseType):
+    """IPRange type.
+
+    This type represents an IP range as a string. The string is expected
+    to be in the format: <start_ip>-<end_ip>
+    where <start_ip> and <end_ip> are valid IPv4 address.
+    """
+
+    SEPARATOR = "-"
+
+    def __init__(self, **kwargs):
+        super(IPRange, self).__init__(openapi_type="string", **kwargs)
+
+    def validate(self, value):
+        return isinstance(value, netaddr.IPRange)
+
+    def to_simple_type(self, value):
+        return str(value)
+
+    def from_simple_type(self, value):
+        return netaddr.IPRange(*value.split(self.SEPARATOR))
+
+    def from_unicode(self, value):
+        return self.from_simple_type(value)

--- a/restalchemy/tests/unit/dm/test_types_network.py
+++ b/restalchemy/tests/unit/dm/test_types_network.py
@@ -13,6 +13,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import netaddr
 import unittest
 
 from restalchemy.dm import types_network
@@ -262,3 +263,33 @@ class FQDNTest(unittest.TestCase):
         ]
         for fqdn in data:
             self.assertFalse(self.fqdn_2level.validate(fqdn), fqdn)
+
+
+class IPRangeTest(unittest.TestCase):
+    def setUp(self):
+        self.ip_range = types_network.IPRange()
+
+    def test_validate(self):
+        correct_range = netaddr.IPRange("10.0.0.0", "10.0.1.0")
+        self.assertTrue(self.ip_range.validate(correct_range))
+
+        incorrect_range = "10.0.0.0-10.0.1.0"
+        self.assertFalse(self.ip_range.validate(incorrect_range))
+
+    def test_to_simple_type(self):
+        foo_range = netaddr.IPRange("10.0.0.0", "10.0.1.0")
+        self.assertEqual(
+            self.ip_range.to_simple_type(foo_range), "10.0.0.0-10.0.1.0"
+        )
+
+    def test_from_simple_type(self):
+        foo_range = netaddr.IPRange("10.0.0.0", "10.0.1.0")
+        self.assertEqual(
+            self.ip_range.from_simple_type("10.0.0.0-10.0.1.0"), foo_range
+        )
+
+    def test_from_unicode(self):
+        foo_range = netaddr.IPRange("10.0.0.0", "10.0.1.0")
+        self.assertEqual(
+            self.ip_range.from_unicode("10.0.0.0-10.0.1.0"), foo_range
+        )


### PR DESCRIPTION
This type represents an IP range as a string. The string is expected to be in the format: <start_ip>-<end_ip> where <start_ip> and <end_ip> are valid IPv4 addresses.