### PR TITLE
Consider the nested type in TypeError exception

### DIFF
--- a/restalchemy/common/exceptions.py
+++ b/restalchemy/common/exceptions.py
@@ -146,8 +146,17 @@ class TypeError(RestAlchemyException, TypeError):
     def __init__(self, value, property_type):
         self._value = value
         self._property_type = property_type
+
+        # Consider the nested type in output message
+        if hasattr(property_type, "nested_type"):
+            outer_type = type(property_type).__name__
+            inner_type = type(property_type.nested_type).__name__
+            property_type = f"{outer_type}({inner_type})"
+        else:
+            property_type = type(property_type).__name__
+
         super(TypeError, self).__init__(
-            value=value, property_type=type(property_type).__name__
+            value=value, property_type=property_type
         )
 
     def get_value(self):


### PR DESCRIPTION
The output of TypeError becomes useless if the actual type is nested. This fix changes the error message and adds information about a nested type in the output.

For instance, there is a property

```python
properties.property(types.AllowNone(IPRange()))
```

Before:

```
TypeError: Invalid type value '10.0.0.100,10.0.0.200' for 'AllowNone'.
```

After:

```
TypeError: Invalid type value '10.0.0.100,10.0.0.200' for 'AllowNone(IPRange)'.
```