### PR TITLE
Controllers' filters: optimize + return 400 error on unexpected name

### DIFF
--- a/restalchemy/common/exceptions.py
+++ b/restalchemy/common/exceptions.py
@@ -228,6 +228,11 @@ class ValidationPropertyIncompatibleError(ValidationErrorException):
     message = "%(val)s is not compatible with model %(model)s"
 
 
+class ValidationFilterIncompatibleError(ValidationErrorException):
+
+    message = "Filter %(val)s is not supported"
+
+
 class NotEqualUuidException(RestAlchemyException):
 
     message = (


### PR DESCRIPTION
- for every filter in request we create a generator with all of model's fields just to get one, add methods to get only one field from python's dict efficiently
- return valid short 400 http error if filter name is not expected