### PR TITLE
Fix sorted pagination

### DIFF
--- a/restalchemy/common/exceptions.py
+++ b/restalchemy/common/exceptions.py
@@ -247,6 +247,11 @@ class ValidationSortIncompatibleDirCountError(ValidationErrorException):
     message = "Number of sort keys and directions is not equal."
 
 
+class ValidationSortNumberError(ValidationErrorException):
+
+    message = "Only one field can be sorted with such request."
+
+
 class NotEqualUuidException(RestAlchemyException):
 
     message = (


### PR DESCRIPTION
Pagination by marker is based on sort order,
so to get valid order we need a marker based on order field.

Get appropriate marker based on column's id
and support case with non-unique fields by additional sorting by id and removing already sent fields by where id>ID