### PR TITLE
PG pool: set open=True explicitly

### DIFF
--- a/restalchemy/storage/sql/engines.py
+++ b/restalchemy/storage/sql/engines.py
@@ -328,6 +328,11 @@ class PgSQLEngine(AbstractEngine):
             config=config,
             query_cache=query_cache,
         )
+
+        # RA expects the pool to be ready to use
+        if not "open" in self._config:
+            self._config["open"] = True
+
         self._pool = psycopg_pool.ConnectionPool(
             conninfo=db_url,
             configure=self._conn_configure_callback,


### PR DESCRIPTION
There's a deprecation warning:
```
psycopg_pool/pool.py:119: DeprecationWarning:
the default for the ConnectionPool 'open'
parameter will become 'False' in a future release.
Please use open={True|False} explicitly...
```

In RA we expect connection pool to be always ready, so set open=True explicitly.