### PR TITLE
Added new RecordNameWithWildcard net type

### DIFF
--- a/restalchemy/dm/types_network.py
+++ b/restalchemy/dm/types_network.py
@@ -108,6 +108,11 @@ class RecordName(types.BaseCompiledRegExpTypeFromAttr):
         return converted_value if len(converted_value) > 0 else "@"
 
 
+class RecordNameWithWildcard(RecordName):
+    # Difference - allow wildcard at the beginning of domain name.
+    pattern = re.compile(r"^(\*\.){0,1}([a-zA-Z0-9-_]{1,61}\.{0,1}){0,30}$")
+
+
 class SrvName(RecordName):
     def validate(self, value):
         parts = value.split(".")

--- a/restalchemy/tests/unit/dm/test_types_network.py
+++ b/restalchemy/tests/unit/dm/test_types_network.py
@@ -52,6 +52,39 @@ class RecordNameTestCase(unittest.TestCase):
         self.assertFalse(self.test_instance.validate("ee.ёёё.ЕЁ"))
 
 
+class RecordNameWithWildcardTestCase(unittest.TestCase):
+
+    def setUp(self):
+        super(RecordNameWithWildcardTestCase, self).setUp()
+        self.test_instance = types_network.RecordNameWithWildcard()
+
+    def test_validate_correct_value(self):
+        self.assertTrue(
+            self.test_instance.validate("*.ns1.ra.restalchemy.com")
+        )
+        self.assertTrue(self.test_instance.validate("ns1.ra.restalchemy.com"))
+        self.assertTrue(self.test_instance.validate("*.restalchemy.com"))
+        self.assertTrue(self.test_instance.validate("restalchemy.com"))
+
+    def test_from_simple_type(self):
+        self.assertEqual(self.test_instance.from_simple_type("*.x."), "*.x")
+        self.assertEqual(
+            self.test_instance.from_simple_type("*.x.x."), "*.x.x"
+        )
+
+    def test_to_simple_type(self):
+        self.assertEqual(self.test_instance.to_simple_type("*.xxx"), "*.xxx")
+
+    def test_validate_incorrect_value(self):
+        self.assertFalse(self.test_instance.validate("*.a..b.s"))
+        self.assertFalse(self.test_instance.validate("a.*.b.s"))
+        self.assertFalse(self.test_instance.validate(".a.b.s"))
+        self.assertFalse(self.test_instance.validate("*a.b.s"))
+        self.assertFalse(self.test_instance.validate("a.b.s*"))
+        self.assertFalse(self.test_instance.validate("a.b*.s"))
+        self.assertFalse(self.test_instance.validate("a.b.s..*"))
+
+
 class SrvNameTest(unittest.TestCase):
     def setUp(self):
         self.srv_record = types_network.SrvName()


### PR DESCRIPTION
Almost the same as `RecordName` but with ability to type `*` at the beginning of a record.

Examples:
```
*.restalchemy.com
*.ns1.ra.restalchemy.com
```