### PR TITLE
SchemeDict/SoftSchemeDict.to_openapi_spec method fix 

### DIFF
--- a/restalchemy/dm/types.py
+++ b/restalchemy/dm/types.py
@@ -573,7 +573,7 @@ class SoftSchemeDict(Dict):
 
     def to_openapi_spec(self, prop_kwargs):
         spec = {"type": "object", "properties": {}}
-        for k, v in self.__scheme__.items():
+        for k, v in self._scheme.items():
             spec["properties"][k] = v.to_openapi_spec(prop_kwargs)
         return spec
 
@@ -610,7 +610,7 @@ class SchemeDict(Dict):
 
     def to_openapi_spec(self, prop_kwargs):
         spec = {"type": "object", "properties": {}}
-        for k, v in self.__scheme__.items():
+        for k, v in self._scheme.items():
             spec["properties"][k] = v.to_openapi_spec(prop_kwargs)
         return spec
 


### PR DESCRIPTION
Fixes this error, which happens on Swagger/OpenAPI specs generation:
```
Traceback:
...
  File "/lib/python3.12/site-packages/restalchemy/api/resources.py", line 556, in generate_schema_object
    properties[prop.api_name] = prop.get_type().to_openapi_spec(
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/lib/python3.12/site-packages/restalchemy/dm/types.py", line 976, in to_openapi_spec
    spec = self._nested_type.to_openapi_spec(prop_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/lib/python3.12/site-packages/restalchemy/dm/types.py", line 576, in to_openapi_spec
    for k, v in self.__scheme__.items():
                ^^^^^^^^^^^^^^^
AttributeError: 'SoftSchemeDict' object has no attribute '__scheme__'.
```