### PR TITLE
Relationship: add get_property_type method

### DIFF
--- a/restalchemy/dm/relationships.py
+++ b/restalchemy/dm/relationships.py
@@ -109,6 +109,9 @@ class Relationship(BaseRelationship):
     def property_type(self):
         return self._type
 
+    def get_property_type(self):
+        return self._type
+
     @classmethod
     def is_id_property(self):
         return False


### PR DESCRIPTION
It may be needed to work with Relationship as with Property.

Otherwise we may have such problems with dynamic_types:
```
  File ".../gcl_iam/controllers.py", line 134, in create
    return super(PolicyBasedControllerMixin, self).create(**kwargs)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File ".../restalchemy/api/controllers.py", line 403, in create
    return super(BaseNestedResourceController, self).create(
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        **self._prepare_kwargs(**kwargs)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File ".../restalchemy/api/controllers.py", line 319, in create
    dm.insert()
    ~~~~~~~~~^^
  File ".../restalchemy/storage/base.py", line 97, in wrapper
    raise exceptions.UnknownStorageException(caused=e)
restalchemy.storage.exceptions.UnknownStorageException: Unknown storage exception: AttributeError("'Relationship' object has no attribute 'get_property_type'")
```