### PR TITLE
Bugfix: Convert model without ID to string

### DIFF
--- a/restalchemy/dm/models.py
+++ b/restalchemy/dm/models.py
@@ -215,7 +215,7 @@ class Model(collections_abc.Mapping, metaclass=MetaModel):
         return len(self.properties)
 
     def __str__(self):
-        return "<%s %s>" % (self.__class__.__name__, self.get_id())
+        return "<%s %s>" % (self.__class__.__name__, self.as_plain_dict())
 
     def __repr__(self):
         result = []
@@ -240,6 +240,9 @@ class ModelWithID(Model):
 
     def __hash__(self):
         return hash(str(self.get_id()))
+
+    def __str__(self):
+        return "<%s %s>" % (self.__class__.__name__, self.get_id())
 
 
 class ModelWithUUID(ModelWithID):


### PR DESCRIPTION
Before:
```
Aug 13 19:54:59 ubuntu genesis-db-gservice[4827]: --- Logging error ---
Aug 13 19:54:59 ubuntu genesis-db-gservice[4827]: Traceback (most recent call last):
Aug 13 19:54:59 ubuntu genesis-db-gservice[4827]:   File "/opt/genesis_db/.venv/lib/python3.12/site-packages/restalchemy/dm/models.py", line 105, in __getattr__
Aug 13 19:54:59 ubuntu genesis-db-gservice[4827]:     return self.properties[name].value
Aug 13 19:54:59 ubuntu genesis-db-gservice[4827]:            ~~~~~~~~~~~~~~~^^^^^^
Aug 13 19:54:59 ubuntu genesis-db-gservice[4827]:   File "/opt/genesis_db/.venv/lib/python3.12/site-packages/restalchemy/dm/properties.py", line 178, in __getitem__
Aug 13 19:54:59 ubuntu genesis-db-gservice[4827]:     return self.properties[name]
Aug 13 19:54:59 ubuntu genesis-db-gservice[4827]:            ~~~~~~~~~~~~~~~^^^^^^
Aug 13 19:54:59 ubuntu genesis-db-gservice[4827]:   File "/opt/genesis_db/.venv/lib/python3.12/site-packages/restalchemy/common/utils.py", line 42, in __getitem__
Aug 13 19:54:59 ubuntu genesis-db-gservice[4827]:     return self._d[key]
Aug 13 19:54:59 ubuntu genesis-db-gservice[4827]:            ~~~~~~~^^^^^
Aug 13 19:54:59 ubuntu genesis-db-gservice[4827]: KeyError: 'get_id'
Aug 13 19:54:59 ubuntu genesis-db-gservice[4827]: During handling of the above exception, another exception occurred:
Aug 13 19:54:59 ubuntu genesis-db-gservice[4827]: Traceback (most recent call last):
Aug 13 19:54:59 ubuntu genesis-db-gservice[4827]:   File "/usr/lib/python3.12/logging/__init__.py", line 1160, in emit
Aug 13 19:54:59 ubuntu genesis-db-gservice[4827]:     msg = self.format(record)
Aug 13 19:54:59 ubuntu genesis-db-gservice[4827]:           ^^^^^^^^^^^^^^^^^^^
Aug 13 19:54:59 ubuntu genesis-db-gservice[4827]:   File "/usr/lib/python3.12/logging/__init__.py", line 999, in format
Aug 13 19:54:59 ubuntu genesis-db-gservice[4827]:     return fmt.format(record)
Aug 13 19:54:59 ubuntu genesis-db-gservice[4827]:            ^^^^^^^^^^^^^^^^^^
Aug 13 19:54:59 ubuntu genesis-db-gservice[4827]:   File "/usr/lib/python3.12/logging/__init__.py", line 703, in format
Aug 13 19:54:59 ubuntu genesis-db-gservice[4827]:     record.message = record.getMessage()
Aug 13 19:54:59 ubuntu genesis-db-gservice[4827]:                      ^^^^^^^^^^^^^^^^^^^
Aug 13 19:54:59 ubuntu genesis-db-gservice[4827]:   File "/usr/lib/python3.12/logging/__init__.py", line 392, in getMessage
Aug 13 19:54:59 ubuntu genesis-db-gservice[4827]:     msg = msg % self.args
Aug 13 19:54:59 ubuntu genesis-db-gservice[4827]:           ~~~~^~~~~~~~~~~
Aug 13 19:54:59 ubuntu genesis-db-gservice[4827]:   File "/opt/genesis_db/.venv/lib/python3.12/site-packages/restalchemy/dm/models.py", line 218, in __str__
Aug 13 19:54:59 ubuntu genesis-db-gservice[4827]:     return "<%s %s>" % (self.__class__.__name__, self.get_id())
```

After:
```
<Payload {'capabilities': {}, 'facts': {}, 'hash': '831154110e30ac6a', 'version': 0}>
```