### PR TITLE
Pagination heavily refactored

### DIFF
--- a/restalchemy/tests/utils.py
+++ b/restalchemy/tests/utils.py
@@ -1,0 +1,11 @@
+def make_test_name(testcase_func, param_num, param):
+    """
+    Generic name function for parameterized tests
+    Example:
+        test_smth_1_arg1.1_arg2.1
+        test_smth_2_arg1.2_arg2.1
+        test_smth_3_arg1.3_arg2.1
+                  ^^^^^^^^^^^^^^^
+    """
+    params_str = "_".join(str(i) for i in param[0])
+    return f"{testcase_func.__name__}_{param_num}_{params_str}"

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,3 +4,4 @@ urllib3>=1.26.19,<2.0.0  # MIT
 pytest>=8.0.0,<9.0.0  # MIT License (MIT)
 pytest-timer>=1.0.0,<2.0.0  # MIT License (MIT)
 pytest-cov>=5.0.0,<7.0.0  # MIT License (MIT)
+parameterized>=0.9.0,<1.0.0  # BSD


### PR DESCRIPTION
 to support more corner cases like:
 - sort by UUID DESC
 - sort by default with page_limit=0/null
 - etc

Tested on all combos from:
```
("page_limit", [0, 1, 3, 999, None])
("sort_key", [None, "uuid", "name", "created_at"])
("sort_dir", [None, "asc", "desc"])
```