### PR TITLE
Add ContainsAll/ContainsAny filter operators for array columns

### DIFF
--- a/restalchemy/dm/filters.py
+++ b/restalchemy/dm/filters.py
@@ -87,13 +87,25 @@ class NotLike(AbstractClause):
 class ContainsAll(AbstractClause):
     """Array @> operator: column contains all specified elements."""
 
-    pass
+    def __init__(self, value):
+        if not isinstance(value, (list, tuple, set)):
+            raise TypeError(
+                "%s value must be a list, tuple, or set, not %s"
+                % (type(self).__name__, type(value).__name__)
+            )
+        super().__init__(value)
 
 
 class ContainsAny(AbstractClause):
     """Array && operator: column contains at least one of the specified elements."""
 
-    pass
+    def __init__(self, value):
+        if not isinstance(value, (list, tuple, set)):
+            raise TypeError(
+                "%s value must be a list, tuple, or set, not %s"
+                % (type(self).__name__, type(value).__name__)
+            )
+        super().__init__(value)
 
 
 class AbstractExpression(metaclass=abc.ABCMeta):

--- a/restalchemy/dm/filters.py
+++ b/restalchemy/dm/filters.py
@@ -84,6 +84,18 @@ class NotLike(AbstractClause):
     pass
 
 
+class ContainsAll(AbstractClause):
+    """Array @> operator: column contains all specified elements."""
+
+    pass
+
+
+class ContainsAny(AbstractClause):
+    """Array && operator: column contains at least one of the specified elements."""
+
+    pass
+
+
 class AbstractExpression(metaclass=abc.ABCMeta):
     def __init__(self, *clauses):
         super(AbstractExpression, self).__init__()

--- a/restalchemy/dm/filters.py
+++ b/restalchemy/dm/filters.py
@@ -87,25 +87,13 @@ class NotLike(AbstractClause):
 class ContainsAll(AbstractClause):
     """Array @> operator: column contains all specified elements."""
 
-    def __init__(self, value):
-        if not isinstance(value, (list, tuple, set)):
-            raise TypeError(
-                "%s value must be a list, tuple, or set, not %s"
-                % (type(self).__name__, type(value).__name__)
-            )
-        super().__init__(value)
+    pass
 
 
 class ContainsAny(AbstractClause):
     """Array && operator: column contains at least one of the specified elements."""
 
-    def __init__(self, value):
-        if not isinstance(value, (list, tuple, set)):
-            raise TypeError(
-                "%s value must be a list, tuple, or set, not %s"
-                % (type(self).__name__, type(value).__name__)
-            )
-        super().__init__(value)
+    pass
 
 
 class AbstractExpression(metaclass=abc.ABCMeta):

--- a/restalchemy/storage/sql/filters.py
+++ b/restalchemy/storage/sql/filters.py
@@ -141,6 +141,20 @@ class NotLike(AbstractClause):
         return ("%s NOT LIKE " % self.column) + "%s"
 
 
+class PostgreSqlContainsAll(AbstractClause):
+    """Array @>: column contains all elements of the given array."""
+
+    def construct_expression(self):
+        return f"{self.column} @> %s"
+
+
+class PostgreSqlContainsAny(AbstractClause):
+    """Array &&: column overlaps with (shares at least one element of) the given array."""
+
+    def construct_expression(self):
+        return f"{self.column} && %s"
+
+
 class AbstractExpression(metaclass=abc.ABCMeta):
     def __init__(self, *clauses):
         super(AbstractExpression, self).__init__()
@@ -228,6 +242,8 @@ FILTER_MAPPING = {
         filters.NotIn: PostgreSqlNotIn,
         filters.Like: Like,
         filters.NotLike: NotLike,
+        filters.ContainsAll: PostgreSqlContainsAll,
+        filters.ContainsAny: PostgreSqlContainsAny,
     },
 }
 

--- a/restalchemy/tests/functional/migrations/test-tags-filter-migration-2d6229.py
+++ b/restalchemy/tests/functional/migrations/test-tags-filter-migration-2d6229.py
@@ -36,6 +36,9 @@ class MigrationStep(migrations.AbstractMigrationStep):
                 PRIMARY KEY (uuid)
             )
         """)
+        session.execute(
+            "CREATE INDEX idx_test_tagged_tags ON test_tagged USING GIN (tags)"
+        )
 
     def downgrade(self, session):
         self._delete_table_if_exists(session, "test_tagged")

--- a/restalchemy/tests/functional/migrations/test-tags-filter-migration-2d6229.py
+++ b/restalchemy/tests/functional/migrations/test-tags-filter-migration-2d6229.py
@@ -1,0 +1,44 @@
+# Copyright 2026 George Melikov
+#
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from restalchemy.storage.sql import migrations
+
+
+class MigrationStep(migrations.AbstractMigrationStep):
+    def __init__(self):
+        self._depends = [""]
+
+    @property
+    def migration_id(self):
+        return "2d622936-e382-4618-871b-77faa5221b3e"
+
+    def upgrade(self, session):
+        if session.engine.dialect.name != "postgresql":
+            return
+        session.execute("""
+            CREATE TABLE test_tagged (
+                uuid UUID NOT NULL,
+                name VARCHAR(255) NOT NULL DEFAULT '',
+                tags TEXT[] NOT NULL DEFAULT '{}',
+                PRIMARY KEY (uuid)
+            )
+        """)
+
+    def downgrade(self, session):
+        self._delete_table_if_exists(session, "test_tagged")
+
+
+migration_step = MigrationStep()

--- a/restalchemy/tests/functional/migrations/test-tags-filter-migration-2d6229.py
+++ b/restalchemy/tests/functional/migrations/test-tags-filter-migration-2d6229.py
@@ -31,11 +31,15 @@ class MigrationStep(migrations.AbstractMigrationStep):
         session.execute("""
             CREATE TABLE test_tagged (
                 uuid UUID NOT NULL,
+                project_id UUID NOT NULL,
                 name VARCHAR(255) NOT NULL DEFAULT '',
                 tags TEXT[] NOT NULL DEFAULT '{}',
                 PRIMARY KEY (uuid)
             )
         """)
+        session.execute(
+            "CREATE INDEX idx_test_tagged_project_id ON test_tagged (project_id)"
+        )
         session.execute(
             "CREATE INDEX idx_test_tagged_tags ON test_tagged USING GIN (tags)"
         )

--- a/restalchemy/tests/functional/storage/pgsql/test_tags_filter.py
+++ b/restalchemy/tests/functional/storage/pgsql/test_tags_filter.py
@@ -19,22 +19,27 @@ import uuid
 
 from restalchemy.dm import filters as dm_filters
 from restalchemy.dm import models
-from restalchemy.dm import properties
-from restalchemy.dm import types
 from restalchemy.storage.sql import orm
 from restalchemy.tests.functional import base
 from restalchemy.tests.functional import consts
 
 
-class TaggedModel(models.ModelWithUUID, models.ModelWithTags, orm.SQLStorableMixin):
+class TaggedModel(
+    models.ModelWithUUID,
+    models.ModelWithProject,
+    models.ModelWithTags,
+    orm.SQLStorableMixin,
+):
     __tablename__ = "test_tagged"
-    name = properties.property(types.String(), default="")
 
 
 UUID1 = uuid.UUID("00000000-0000-0000-0000-000000000001")
 UUID2 = uuid.UUID("00000000-0000-0000-0000-000000000002")
 UUID3 = uuid.UUID("00000000-0000-0000-0000-000000000003")
 UUID4 = uuid.UUID("00000000-0000-0000-0000-000000000004")
+
+PROJECT1 = uuid.UUID("00000000-0000-0000-0001-000000000000")
+PROJECT2 = uuid.UUID("00000000-0000-0000-0002-000000000000")
 
 
 @unittest.skipUnless(
@@ -47,10 +52,14 @@ class TagsFilterTestCase(base.BaseWithDbMigrationsTestCase):
 
     def setUp(self):
         super().setUp()
-        TaggedModel(uuid=UUID1, name="prod-eu", tags=["env:prod", "region:eu"]).save()
-        TaggedModel(uuid=UUID2, name="prod-us", tags=["env:prod", "region:us"]).save()
-        TaggedModel(uuid=UUID3, name="staging", tags=["env:staging"]).save()
-        TaggedModel(uuid=UUID4, name="empty", tags=[]).save()
+        TaggedModel(
+            uuid=UUID1, project_id=PROJECT1, tags=["env:prod", "region:eu"]
+        ).save()
+        TaggedModel(
+            uuid=UUID2, project_id=PROJECT1, tags=["env:prod", "region:us"]
+        ).save()
+        TaggedModel(uuid=UUID3, project_id=PROJECT2, tags=["env:staging"]).save()
+        TaggedModel(uuid=UUID4, project_id=PROJECT2, tags=[]).save()
 
     def _uuids(self, objs):
         return {o.uuid for o in objs}
@@ -74,7 +83,7 @@ class TagsFilterTestCase(base.BaseWithDbMigrationsTestCase):
         self.assertEqual(result, [])
 
     def test_contains_all_empty_list_matches_all(self):
-        # empty array @> empty array is true for every row
+        # empty @> empty is true for every row
         result = TaggedModel.objects.get_all(
             filters={"tags": dm_filters.ContainsAll([])}
         )
@@ -95,5 +104,43 @@ class TagsFilterTestCase(base.BaseWithDbMigrationsTestCase):
     def test_contains_any_no_match(self):
         result = TaggedModel.objects.get_all(
             filters={"tags": dm_filters.ContainsAny(["nonexistent"])}
+        )
+        self.assertEqual(result, [])
+
+    # --- combined with project_id ---
+
+    def test_project_and_contains_all(self):
+        result = TaggedModel.objects.get_all(
+            filters={
+                "project_id": dm_filters.EQ(PROJECT1),
+                "tags": dm_filters.ContainsAll(["env:prod"]),
+            }
+        )
+        self.assertEqual(self._uuids(result), {UUID1, UUID2})
+
+    def test_project_and_contains_all_narrows_result(self):
+        result = TaggedModel.objects.get_all(
+            filters={
+                "project_id": dm_filters.EQ(PROJECT1),
+                "tags": dm_filters.ContainsAll(["env:prod", "region:eu"]),
+            }
+        )
+        self.assertEqual(self._uuids(result), {UUID1})
+
+    def test_project_and_contains_any(self):
+        result = TaggedModel.objects.get_all(
+            filters={
+                "project_id": dm_filters.EQ(PROJECT1),
+                "tags": dm_filters.ContainsAny(["region:eu", "region:us"]),
+            }
+        )
+        self.assertEqual(self._uuids(result), {UUID1, UUID2})
+
+    def test_project_filter_excludes_other_project(self):
+        result = TaggedModel.objects.get_all(
+            filters={
+                "project_id": dm_filters.EQ(PROJECT2),
+                "tags": dm_filters.ContainsAny(["env:prod"]),
+            }
         )
         self.assertEqual(result, [])

--- a/restalchemy/tests/functional/storage/pgsql/test_tags_filter.py
+++ b/restalchemy/tests/functional/storage/pgsql/test_tags_filter.py
@@ -1,0 +1,99 @@
+# Copyright 2026 George Melikov
+#
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import unittest
+import uuid
+
+from restalchemy.dm import filters as dm_filters
+from restalchemy.dm import models
+from restalchemy.dm import properties
+from restalchemy.dm import types
+from restalchemy.storage.sql import orm
+from restalchemy.tests.functional import base
+from restalchemy.tests.functional import consts
+
+
+class TaggedModel(models.ModelWithUUID, models.ModelWithTags, orm.SQLStorableMixin):
+    __tablename__ = "test_tagged"
+    name = properties.property(types.String(), default="")
+
+
+UUID1 = uuid.UUID("00000000-0000-0000-0000-000000000001")
+UUID2 = uuid.UUID("00000000-0000-0000-0000-000000000002")
+UUID3 = uuid.UUID("00000000-0000-0000-0000-000000000003")
+UUID4 = uuid.UUID("00000000-0000-0000-0000-000000000004")
+
+
+@unittest.skipUnless(
+    consts.get_database_uri().startswith("postgresql"),
+    "ContainsAll/ContainsAny are PostgreSQL-only operators",
+)
+class TagsFilterTestCase(base.BaseWithDbMigrationsTestCase):
+    __LAST_MIGRATION__ = "test-tags-filter-migration-2d6229"
+    __FIRST_MIGRATION__ = "test-tags-filter-migration-2d6229"
+
+    def setUp(self):
+        super().setUp()
+        TaggedModel(uuid=UUID1, name="prod-eu", tags=["env:prod", "region:eu"]).save()
+        TaggedModel(uuid=UUID2, name="prod-us", tags=["env:prod", "region:us"]).save()
+        TaggedModel(uuid=UUID3, name="staging", tags=["env:staging"]).save()
+        TaggedModel(uuid=UUID4, name="empty", tags=[]).save()
+
+    def _uuids(self, objs):
+        return {o.uuid for o in objs}
+
+    def test_contains_all_single_tag(self):
+        result = TaggedModel.objects.get_all(
+            filters={"tags": dm_filters.ContainsAll(["env:prod"])}
+        )
+        self.assertEqual(self._uuids(result), {UUID1, UUID2})
+
+    def test_contains_all_multiple_tags(self):
+        result = TaggedModel.objects.get_all(
+            filters={"tags": dm_filters.ContainsAll(["env:prod", "region:eu"])}
+        )
+        self.assertEqual(self._uuids(result), {UUID1})
+
+    def test_contains_all_no_match(self):
+        result = TaggedModel.objects.get_all(
+            filters={"tags": dm_filters.ContainsAll(["nonexistent"])}
+        )
+        self.assertEqual(result, [])
+
+    def test_contains_all_empty_list_matches_all(self):
+        # empty array @> empty array is true for every row
+        result = TaggedModel.objects.get_all(
+            filters={"tags": dm_filters.ContainsAll([])}
+        )
+        self.assertEqual(len(result), 4)
+
+    def test_contains_any_single_tag(self):
+        result = TaggedModel.objects.get_all(
+            filters={"tags": dm_filters.ContainsAny(["env:staging"])}
+        )
+        self.assertEqual(self._uuids(result), {UUID3})
+
+    def test_contains_any_multiple_tags(self):
+        result = TaggedModel.objects.get_all(
+            filters={"tags": dm_filters.ContainsAny(["region:eu", "region:us"])}
+        )
+        self.assertEqual(self._uuids(result), {UUID1, UUID2})
+
+    def test_contains_any_no_match(self):
+        result = TaggedModel.objects.get_all(
+            filters={"tags": dm_filters.ContainsAny(["nonexistent"])}
+        )
+        self.assertEqual(result, [])

--- a/restalchemy/tests/unit/dm/test_filters.py
+++ b/restalchemy/tests/unit/dm/test_filters.py
@@ -64,6 +64,22 @@ class FilterEqualityTestCase(base.BaseTestCase):
 
 
 class ContainsAllFilterTestCase(base.BaseTestCase):
+    def test_rejects_string(self):
+        with self.assertRaises(TypeError):
+            filters.ContainsAll("env:prod")
+
+    def test_rejects_non_iterable(self):
+        with self.assertRaises(TypeError):
+            filters.ContainsAll(42)
+
+    def test_accepts_tuple(self):
+        f = filters.ContainsAll(("a", "b"))
+        self.assertEqual(f.value, ("a", "b"))
+
+    def test_accepts_set(self):
+        f = filters.ContainsAll({"a"})
+        self.assertIn("a", f.value)
+
     def test_equal(self):
         self.assertEqual(
             filters.ContainsAll(["a", "b"]), filters.ContainsAll(["a", "b"])
@@ -85,6 +101,18 @@ class ContainsAllFilterTestCase(base.BaseTestCase):
 
 
 class ContainsAnyFilterTestCase(base.BaseTestCase):
+    def test_rejects_string(self):
+        with self.assertRaises(TypeError):
+            filters.ContainsAny("env:prod")
+
+    def test_rejects_non_iterable(self):
+        with self.assertRaises(TypeError):
+            filters.ContainsAny(42)
+
+    def test_accepts_tuple(self):
+        f = filters.ContainsAny(("a", "b"))
+        self.assertEqual(f.value, ("a", "b"))
+
     def test_equal(self):
         self.assertEqual(
             filters.ContainsAny(["a", "b"]), filters.ContainsAny(["a", "b"])

--- a/restalchemy/tests/unit/dm/test_filters.py
+++ b/restalchemy/tests/unit/dm/test_filters.py
@@ -64,22 +64,6 @@ class FilterEqualityTestCase(base.BaseTestCase):
 
 
 class ContainsAllFilterTestCase(base.BaseTestCase):
-    def test_rejects_string(self):
-        with self.assertRaises(TypeError):
-            filters.ContainsAll("env:prod")
-
-    def test_rejects_non_iterable(self):
-        with self.assertRaises(TypeError):
-            filters.ContainsAll(42)
-
-    def test_accepts_tuple(self):
-        f = filters.ContainsAll(("a", "b"))
-        self.assertEqual(f.value, ("a", "b"))
-
-    def test_accepts_set(self):
-        f = filters.ContainsAll({"a"})
-        self.assertIn("a", f.value)
-
     def test_equal(self):
         self.assertEqual(
             filters.ContainsAll(["a", "b"]), filters.ContainsAll(["a", "b"])
@@ -101,18 +85,6 @@ class ContainsAllFilterTestCase(base.BaseTestCase):
 
 
 class ContainsAnyFilterTestCase(base.BaseTestCase):
-    def test_rejects_string(self):
-        with self.assertRaises(TypeError):
-            filters.ContainsAny("env:prod")
-
-    def test_rejects_non_iterable(self):
-        with self.assertRaises(TypeError):
-            filters.ContainsAny(42)
-
-    def test_accepts_tuple(self):
-        f = filters.ContainsAny(("a", "b"))
-        self.assertEqual(f.value, ("a", "b"))
-
     def test_equal(self):
         self.assertEqual(
             filters.ContainsAny(["a", "b"]), filters.ContainsAny(["a", "b"])

--- a/restalchemy/tests/unit/dm/test_filters.py
+++ b/restalchemy/tests/unit/dm/test_filters.py
@@ -61,3 +61,41 @@ class FilterEqualityTestCase(base.BaseTestCase):
         f2 = filters.AND([filters.EQ(4), filters.NE(10)])
 
         self.assertNotEqual(f1, f2)
+
+
+class ContainsAllFilterTestCase(base.BaseTestCase):
+    def test_equal(self):
+        self.assertEqual(
+            filters.ContainsAll(["a", "b"]), filters.ContainsAll(["a", "b"])
+        )
+
+    def test_not_equal_value(self):
+        self.assertNotEqual(filters.ContainsAll(["a"]), filters.ContainsAll(["b"]))
+
+    def test_not_equal_type(self):
+        self.assertNotEqual(filters.ContainsAll(["a"]), filters.ContainsAny(["a"]))
+
+    def test_repr(self):
+        f = filters.ContainsAll(["x"])
+        self.assertIn("ContainsAll", repr(f))
+
+    def test_str(self):
+        f = filters.ContainsAll(["x", "y"])
+        self.assertEqual(str(f), str(["x", "y"]))
+
+
+class ContainsAnyFilterTestCase(base.BaseTestCase):
+    def test_equal(self):
+        self.assertEqual(
+            filters.ContainsAny(["a", "b"]), filters.ContainsAny(["a", "b"])
+        )
+
+    def test_not_equal_value(self):
+        self.assertNotEqual(filters.ContainsAny(["a"]), filters.ContainsAny(["b"]))
+
+    def test_not_equal_type(self):
+        self.assertNotEqual(filters.ContainsAny(["a"]), filters.ContainsAll(["a"]))
+
+    def test_repr(self):
+        f = filters.ContainsAny(["x"])
+        self.assertIn("ContainsAny", repr(f))

--- a/restalchemy/tests/unit/storage/sql/test_filters.py
+++ b/restalchemy/tests/unit/storage/sql/test_filters.py
@@ -489,6 +489,68 @@ class NotLikeTestCase(base.BaseTestCase):
         self.assertEqual(self._expr.value, TEST_VALUE)
 
 
+class TaggedModel(models.Model):
+    tags = properties.property(types.TypedList(types.String()), default=list)
+
+
+class PostgreSqlContainsAllTestCase(base.BaseTestCase):
+    TEST_TAGS = ["env:prod", "region:us"]
+
+    def setUp(self):
+        self._expr = filters.PostgreSqlContainsAll(
+            column=TEST_NAME,
+            value_type=common.AsIsType(),
+            value=self.TEST_TAGS,
+            session=fixtures.SessionFixture(),
+        )
+
+    def test_construct_expression(self):
+        self.assertEqual(TEST_NAME + " @> %s", self._expr.construct_expression())
+
+    def test_value_property(self):
+        self.assertEqual(self._expr.value, self.TEST_TAGS)
+
+
+class PostgreSqlContainsAnyTestCase(base.BaseTestCase):
+    TEST_TAGS = ["env:prod", "region:us"]
+
+    def setUp(self):
+        self._expr = filters.PostgreSqlContainsAny(
+            column=TEST_NAME,
+            value_type=common.AsIsType(),
+            value=self.TEST_TAGS,
+            session=fixtures.SessionFixture(),
+        )
+
+    def test_construct_expression(self):
+        self.assertEqual(TEST_NAME + " && %s", self._expr.construct_expression())
+
+    def test_value_property(self):
+        self.assertEqual(self._expr.value, self.TEST_TAGS)
+
+
+class PostgreSqlContainsAllConvertFiltersTestCase(base.BaseTestCase):
+    def test_containsall_uses_at_gt_operator(self):
+        processed = filters.convert_filters(
+            TaggedModel,
+            {"tags": dm_filters.ContainsAll(["env:prod", "region:us"])},
+            session=_PostgreSqlSessionFixture(),
+        )
+        self.assertEqual('"tags" @> %s', processed.construct_expression())
+        self.assertEqual([["env:prod", "region:us"]], processed.value)
+
+
+class PostgreSqlContainsAnyConvertFiltersTestCase(base.BaseTestCase):
+    def test_containsany_uses_overlap_operator(self):
+        processed = filters.convert_filters(
+            TaggedModel,
+            {"tags": dm_filters.ContainsAny(["env:prod", "env:staging"])},
+            session=_PostgreSqlSessionFixture(),
+        )
+        self.assertEqual('"tags" && %s', processed.construct_expression())
+        self.assertEqual([["env:prod", "env:staging"]], processed.value)
+
+
 class ConvertFiltersTestCase(base.BaseTestCase):
     def test_convert_filters_new(self):
         d = collections.OrderedDict()


### PR DESCRIPTION
Introduces dm-level ContainsAll (@>) and ContainsAny (&&) filter operators for filtering ModelWithTags by tag arrays in PostgreSQL.

Closes #119