### PR TITLE
Add controller auto filters and values

### DIFF
--- a/restalchemy/api/controllers.py
+++ b/restalchemy/api/controllers.py
@@ -82,6 +82,55 @@ class Controller(object):
             charset=charset,
         )
 
+    def get_autofilters(self):
+        """Return filters that must be applied when selecting resources.
+
+        Override this method in a controller to restrict the objects visible
+        to controller methods such as ``get``, ``filter``, ``update`` and
+        ``delete``. Returned values should use the same format as regular
+        controller filters: field names mapped to ``restalchemy.dm.filters``
+        clauses.
+
+        Example:
+            def get_autofilters(self):
+                project_id = self.request.context.project_id
+                return {"project_id": dm_filters.EQ(project_id)}
+        """
+        return {}
+
+    def get_autovalues(self):
+        """Return values that must be applied to every create/update request.
+
+        Override this method in a controller to inject server-side values into
+        payloads before they are passed to ``create`` or ``update``. Returned
+        values should be plain model field values, not filter clauses.
+
+        Example:
+            def get_autovalues(self):
+                context = self.request.context
+                return {
+                    "project_id": context.project_id,
+                    "updated_by": context.user_id,
+                }
+        """
+        return {}
+
+    def _apply_autofilters(self, filters):
+        autofilters = self.get_autofilters()
+        if not autofilters:
+            return filters
+        filters = filters.copy()
+        filters.update(autofilters)
+        return filters
+
+    def _apply_autovalues(self, values):
+        autovalues = self.get_autovalues()
+        if not autovalues:
+            return values
+        values = values.copy()
+        values.update(autovalues)
+        return values
+
     def process_result(self, result, status_code=200, headers=None, add_location=False):
         headers = headers or {}
 
@@ -297,14 +346,17 @@ class Controller(object):
 
 class BaseResourceController(Controller):
     def create(self, **kwargs):
+        kwargs = self._apply_autovalues(kwargs)
         dm = self.model(**kwargs)
         dm.insert()
         return dm
 
     def get(self, uuid, **kwargs):
         # TODO(d.burmistrov): replace this hack with normal argument passing
-        kwargs[self.model.get_id_property_name()] = dm_filters.EQ(uuid)
-        return self.model.objects.get_one(filters=kwargs)
+        filters = kwargs.copy()
+        filters[self.model.get_id_property_name()] = dm_filters.EQ(uuid)
+        filters = self._apply_autofilters(filters)
+        return self.model.objects.get_one(filters=filters)
 
     def _split_filters(self, filters):
         if hasattr(self.model, "get_custom_properties"):
@@ -354,6 +406,7 @@ class BaseResourceController(Controller):
         return filters
 
     def filter(self, filters, order_by=None):
+        filters = self._apply_autofilters(filters)
         custom_filters, storage_filters = self._split_filters(filters)
 
         result = self._process_storage_filters(storage_filters, order_by=order_by)
@@ -365,6 +418,7 @@ class BaseResourceController(Controller):
 
     def update(self, uuid, **kwargs):
         dm = self.get(uuid=uuid)
+        kwargs = self._apply_autovalues(kwargs)
         dm.update_dm(values=kwargs)
         dm.update()
         return dm
@@ -401,6 +455,7 @@ class BaseNestedResourceController(BaseResourceController):
 
     def update(self, parent_resource, uuid, **kwargs):
         dm = self.get(parent_resource=parent_resource, uuid=uuid)
+        kwargs = self._apply_autovalues(kwargs)
         dm.update_dm(values=kwargs)
         dm.update()
         return dm
@@ -412,7 +467,14 @@ class PaginationFilterBuilder:
     Handles non-trivial logic for paginating by non-unique column.
     """
 
-    def __init__(self, model, marker_id, sort_column=None, sort_direction="asc"):
+    def __init__(
+        self,
+        model,
+        marker_id,
+        sort_column=None,
+        sort_direction="asc",
+        marker_filters=None,
+    ):
         """
         Create pagination cursor from marker ID.
 
@@ -441,11 +503,13 @@ class PaginationFilterBuilder:
             marker_id: The ID of the last row from previous page
             sort_column: Column name to sort by (None for ID-only sort)
             sort_direction: "asc" or "desc"
+            marker_filters: Filters that must also match the marker row
         """
         self.marker_id = marker_id
         self.sort_col = sort_column
         self.sort_dir = sort_direction
         self.id_name = model.get_id_property_name()
+        self.marker_filters = marker_filters
         self.sort_value = self._fetch_sort_val(model)
 
     def _fetch_sort_val(self, model):
@@ -454,10 +518,13 @@ class PaginationFilterBuilder:
         if self.sort_col in (None, self.id_name):
             return self.marker_id
 
-        # Get last seen row
-        marker_row = model.objects.get_one(
-            filters={self.id_name: dm_filters.EQ(self.marker_id)}
-        )
+        if self.marker_filters:
+            marker_filters = self.marker_filters.copy()
+        else:
+            marker_filters = {}
+        marker_filters[self.id_name] = dm_filters.EQ(self.marker_id)
+
+        marker_row = model.objects.get_one(filters=marker_filters)
         return getattr(marker_row, self.sort_col)
 
     def build_filter(self):
@@ -582,6 +649,7 @@ class BasePaginationMixin(object):
                 self._pagination_marker,
                 sort_col,
                 sort_dir,
+                marker_filters=filters,
             )
             pagination_filters = cursor.build_filter()
             filters = dm_filters.AND(pagination_filters, filters)
@@ -599,6 +667,7 @@ class BasePaginationMixin(object):
         return filters, order_by
 
     def paginated_filter(self, filters, order_by=None):
+        filters = self._apply_autofilters(filters)
         custom_filters, storage_filters = self._split_filters(filters)
 
         cleaned_results = []

--- a/restalchemy/tests/unit/api/test_controllers.py
+++ b/restalchemy/tests/unit/api/test_controllers.py
@@ -20,6 +20,7 @@ import mock
 
 from restalchemy.api import controllers
 from restalchemy.api import packers
+from restalchemy.dm import filters as dm_filters
 
 FAKE_LOCATION_PATH = "fake location path"
 
@@ -105,4 +106,243 @@ class TestRawResponses(unittest.TestCase):
         self.assertEqual(
             result.headers["Content-Disposition"],
             headers["Content-Disposition"],
+        )
+
+
+class FakeResource(object):
+    def __init__(self, model):
+        self._model = model
+
+    def get_model(self):
+        return self._model
+
+
+class FakeModel(object):
+    objects = mock.Mock()
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.insert = mock.Mock()
+
+    @classmethod
+    def get_id_property_name(cls):
+        return "uuid"
+
+
+class FakeItem(object):
+    uuid = "resource-id"
+
+
+class AutoBaseController(controllers.BaseResourceController):
+    __resource__ = FakeResource(FakeModel)
+
+    def get_autofilters(self):
+        return {"project_id": dm_filters.EQ("project-id")}
+
+    def get_autovalues(self):
+        return {
+            "project_id": "project-id",
+            "updated_by": "user-id",
+        }
+
+
+class AutoNestedController(controllers.BaseNestedResourceController):
+    __resource__ = FakeResource(FakeModel)
+    __pr_name__ = "parent"
+
+    def get_autofilters(self):
+        return {"project_id": dm_filters.EQ("project-id")}
+
+    def get_autovalues(self):
+        return {
+            "project_id": "project-id",
+            "updated_by": "user-id",
+        }
+
+
+class AutoPaginatedController(
+    controllers.BaseResourceControllerPaginated,
+):
+    __resource__ = FakeResource(FakeModel)
+
+    def get_autofilters(self):
+        return {"project_id": dm_filters.EQ("project-id")}
+
+
+class TestAutoFiltersAndValues(unittest.TestCase):
+    def setUp(self):
+        super(TestAutoFiltersAndValues, self).setUp()
+        FakeModel.objects = mock.Mock()
+
+    def test_empty_autofilters_do_not_copy_filters(self):
+        controller = controllers.Controller(None)
+        filters = {"state": dm_filters.EQ("active")}
+
+        result = controller._apply_autofilters(filters)
+
+        self.assertIs(filters, result)
+
+    def test_empty_autovalues_do_not_copy_values(self):
+        controller = controllers.Controller(None)
+        values = {"name": "server"}
+
+        result = controller._apply_autovalues(values)
+
+        self.assertIs(values, result)
+
+    def test_base_create_applies_autovalues(self):
+        controller = AutoBaseController(None)
+
+        result = controller.create(name="server", project_id="request-project")
+
+        self.assertEqual(
+            {
+                "name": "server",
+                "project_id": "project-id",
+                "updated_by": "user-id",
+            },
+            result.kwargs,
+        )
+        result.insert.assert_called_once_with()
+
+    def test_base_get_applies_autofilters(self):
+        controller = AutoBaseController(None)
+        expected = mock.Mock()
+        FakeModel.objects.get_one.return_value = expected
+
+        result = controller.get(uuid="resource-id")
+
+        self.assertIs(expected, result)
+        filters = FakeModel.objects.get_one.call_args[1]["filters"]
+        self.assertEqual(
+            {
+                "uuid": dm_filters.EQ("resource-id"),
+                "project_id": dm_filters.EQ("project-id"),
+            },
+            filters,
+        )
+
+    def test_base_filter_applies_autofilters(self):
+        controller = AutoBaseController(None)
+        FakeModel.objects.get_all.return_value = []
+
+        controller.filter(filters={"state": dm_filters.EQ("active")})
+
+        filters = FakeModel.objects.get_all.call_args[1]["filters"]
+        self.assertEqual(
+            {
+                "state": dm_filters.EQ("active"),
+                "project_id": dm_filters.EQ("project-id"),
+            },
+            filters,
+        )
+
+    def test_base_update_applies_autovalues(self):
+        controller = AutoBaseController(None)
+        dm = mock.Mock()
+        FakeModel.objects.get_one.return_value = dm
+
+        controller.update(
+            uuid="resource-id",
+            name="server",
+            project_id="request-project",
+        )
+
+        dm.update_dm.assert_called_once_with(
+            values={
+                "name": "server",
+                "project_id": "project-id",
+                "updated_by": "user-id",
+            },
+        )
+        dm.update.assert_called_once_with()
+
+    def test_nested_filter_applies_parent_and_autofilters(self):
+        controller = AutoNestedController(None)
+        FakeModel.objects.get_all.return_value = []
+
+        controller.filter(
+            parent_resource="parent-id",
+            filters={"state": dm_filters.EQ("active")},
+        )
+
+        filters = FakeModel.objects.get_all.call_args[1]["filters"]
+        self.assertEqual(
+            {
+                "state": dm_filters.EQ("active"),
+                "parent": dm_filters.EQ("parent-id"),
+                "project_id": dm_filters.EQ("project-id"),
+            },
+            filters,
+        )
+
+    def test_nested_update_applies_parent_autofilters_and_autovalues(self):
+        controller = AutoNestedController(None)
+        dm = mock.Mock()
+        FakeModel.objects.get_one.return_value = dm
+
+        controller.update(
+            parent_resource="parent-id",
+            uuid="resource-id",
+            name="server",
+        )
+
+        filters = FakeModel.objects.get_one.call_args[1]["filters"]
+        self.assertEqual(
+            {
+                "parent": "parent-id",
+                "uuid": dm_filters.EQ("resource-id"),
+                "project_id": dm_filters.EQ("project-id"),
+            },
+            filters,
+        )
+        dm.update_dm.assert_called_once_with(
+            values={
+                "name": "server",
+                "project_id": "project-id",
+                "updated_by": "user-id",
+            },
+        )
+        dm.update.assert_called_once_with()
+
+    def test_paginated_filter_applies_autofilters(self):
+        controller = AutoPaginatedController(None)
+        controller._pagination_limit = 1
+        controller._pagination_marker = None
+        FakeModel.objects.get_all.return_value = [FakeItem()]
+
+        result = controller.filter(filters={"state": dm_filters.EQ("active")})
+
+        self.assertEqual([FakeItem.uuid], [item.uuid for item in result])
+        filters = FakeModel.objects.get_all.call_args[1]["filters"]
+        self.assertEqual(
+            {
+                "state": dm_filters.EQ("active"),
+                "project_id": dm_filters.EQ("project-id"),
+            },
+            filters,
+        )
+
+    def test_paginated_marker_lookup_applies_autofilters(self):
+        controller = AutoPaginatedController(None)
+        controller._pagination_limit = 1
+        controller._pagination_marker = "marker-id"
+        marker = mock.Mock()
+        marker.name = "marker-name"
+        FakeModel.objects.get_one.return_value = marker
+        FakeModel.objects.get_all.return_value = []
+
+        controller.filter(
+            filters={"state": dm_filters.EQ("active")},
+            order_by={"name": "asc"},
+        )
+
+        filters = FakeModel.objects.get_one.call_args[1]["filters"]
+        self.assertEqual(
+            {
+                "state": dm_filters.EQ("active"),
+                "project_id": dm_filters.EQ("project-id"),
+                "uuid": dm_filters.EQ("marker-id"),
+            },
+            filters,
         )


### PR DESCRIPTION
## What changed

- Added base controller hooks for automatic filters and create/update values.
- Applied automatic filters in base, nested, and paginated controller selection paths.
- Applied automatic values during create and update flows.
- Added unit coverage for base, nested, and paginated controller behavior.

## Why

Controllers can now enforce server-side selection filters and injected values without repeating that logic in every controller implementation.

## Validation

- tox -e develop -- restalchemy/tests/unit
- tox -e functional -- restalchemy/tests/functional