### PR TITLE
Add JSONFields filter for jsonb columns (#133)

### DIFF
--- a/docs/en/reference/dm/filters.md
+++ b/docs/en/reference/dm/filters.md
@@ -43,6 +43,9 @@ Simple comparison and membership clauses:
 - `NotIn(value)` — not in a collection.
 - `Like(value)` — pattern matching.
 - `NotLike(value)` — negated pattern matching.
+- `ContainsAll(value)` (PostgreSQL array columns) — array `@>`, contains all given elements.
+- `ContainsAny(value)` (PostgreSQL array columns) — array `&&`, overlaps with given elements.
+- `JSONFields(value)` (PostgreSQL jsonb columns) — filter on keys nested inside a jsonb column; see [JSON field filters](#json-field-filters) below.
 
 Example:
 
@@ -130,6 +133,46 @@ print(FooModel.objects.get_one(filters=filter_list))
 ```
 
 Storage backends understand these nested expressions and produce an appropriate query.
+
+---
+
+## JSON field filters
+
+`JSONFields` filters on keys nested inside a PostgreSQL `jsonb` column, and supports both equality and range clauses on those keys — not just containment:
+
+```python
+from restalchemy.dm import filters
+
+# WHERE (spec->>'kind') = %s AND (spec->>'value')::bigint > %s
+FooModel.objects.get_all(
+    filters={"spec": filters.JSONFields({"kind": "foo", "value": filters.GT(10)})}
+)
+```
+
+Each key in the mapping is either a plain scalar (shorthand for `EQ`) or an explicit clause (`EQ`, `NE`, `GT`, `GE`, `LT`, `LE`, `Like`, `NotLike`, `Is`, `IsNot`). Keys are combined with AND. Values are cast in the generated SQL based on their Python type (`bool` → `::boolean`, `int` → `::bigint`, `float` → `::double precision`; `str`/`None` need no cast) — this cast must be reproduced exactly in any index you build (see below), or Postgres will silently ignore the index.
+
+### Indexing a "kind"-discriminated jsonb column
+
+`JSONFields` is meant for the common polymorphic-JSON shape: a column always carries a discriminator key (conventionally `"kind"`), plus a handful of extra keys whose presence and meaning are private to that kind — e.g. `{"kind": "totp", "period": 30}` vs. `{"kind": "yubiotp", "device_id": "..."}` in the same column. This shape needs two kinds of index:
+
+1. **Always index the discriminator itself** with a plain expression index — every query touching the column filters by it first, and it's the same shape for every kind:
+
+   ```sql
+   CREATE INDEX ix_t_spec_kind ON t ((spec->>'kind'));
+   ```
+
+2. **For each `(kind, field)` pair you actually query by, add a *partial* expression index scoped to that kind** — not a table-wide index on the field name, since the field's meaning (and its presence at all) is specific to one kind:
+
+   ```sql
+   CREATE INDEX ix_t_spec_totp_period ON t (((spec->>'period')::bigint))
+       WHERE spec->>'kind' = 'totp';
+   ```
+
+   Measured on a 2M-row table: a query combining the discriminator with a per-kind field (`kind = 'foo' AND value > 10`) was ~2x faster with this partial index than with only the discriminator index from step 1, and a discriminator-only query against a single partial index served as an index-only scan ~9x faster than the plain discriminator index — Postgres can use a partial index's own `WHERE` clause as proof of the predicate. Filtering by several fields of the same kind together should be one composite partial index, not one index per field.
+
+   Don't create a partial index for every `(kind, field)` combination that merely exists in the schema — each one is pure write overhead until a query actually needs it. Add them lazily, driven by real query patterns.
+
+A GIN index (`USING gin(spec)`) does **not** speed up `JSONFields` queries: GIN accelerates `@>`/`?`/`?|`/`?&`, not the `->>` comparisons this filter compiles to, and in testing was sometimes *slower* than a plain sequential scan. It also isn't free on writes — pending-list flushes add write-latency spikes on jsonb columns updated often. Only add GIN if something else in the app genuinely queries with raw containment.
 
 ---
 

--- a/restalchemy/dm/filters.py
+++ b/restalchemy/dm/filters.py
@@ -96,6 +96,34 @@ class ContainsAny(AbstractClause):
     pass
 
 
+class JSONFields(AbstractClause):
+    """Filter on fields nested inside a JSON/JSONB column.
+
+    ``value`` maps a JSON key to either a plain scalar (shorthand for
+    ``EQ``) or another ``AbstractClause`` (``EQ``, ``NE``, ``GT``, ``GE``,
+    ``LT``, ``LE``, ``Like``, ``NotLike``, ``Is``, ``IsNot``) to apply to
+    that key. Multiple keys are combined with AND.
+
+    Example::
+
+        get_all(filters={"spec": JSONFields({"kind": "foo", "value": GT(10)})})
+
+    See ``storage.sql.filters.PostgreSqlJSONFields`` for how this compiles
+    to SQL and what indexes make it fast.
+    """
+
+    def __init__(self, fields):
+        value = {}
+        for key, val in fields.items():
+            if isinstance(val, AbstractExpression):
+                raise ValueError(
+                    "JSONFields does not support expressions (e.g. %s) for "
+                    "key %r" % (type(val).__name__, key)
+                )
+            value[key] = val if isinstance(val, AbstractClause) else EQ(val)
+        super(JSONFields, self).__init__(value)
+
+
 class AbstractExpression(metaclass=abc.ABCMeta):
     def __init__(self, *clauses):
         super(AbstractExpression, self).__init__()

--- a/restalchemy/storage/sql/filters.py
+++ b/restalchemy/storage/sql/filters.py
@@ -16,6 +16,7 @@
 
 import abc
 from collections import abc as collections_abc
+import decimal
 import logging
 
 from restalchemy.dm import filters
@@ -214,6 +215,170 @@ class OR(ClauseList):
     operator = "OR"
 
 
+# Casts applied when comparing a value pulled out of jsonb via ->> (which
+# always yields text or SQL NULL). Keys not listed here (str, None) are
+# compared as-is against the extracted text. This mapping is part of the
+# public contract of PostgreSqlJSONFields: an expression index must use the
+# *exact same* cast, or Postgres will silently ignore it and fall back to a
+# seq scan.
+_JSON_SCALAR_CASTS = {
+    bool: "boolean",
+    int: "bigint",
+    float: "double precision",
+    decimal.Decimal: "numeric",
+}
+
+
+class _JSONFieldClause(AbstractExpression):
+    """One `(column->>'key') [::cast] OP %s` comparison for a JSONFields key.
+
+    The key is inlined into the SQL text as an escaped string literal
+    (quotes doubled, never bound as a parameter): PostgreSQL only matches a
+    query expression against an expression index (e.g. `(spec->>'kind')`)
+    when the two are syntactically identical, and once a prepared
+    statement graduates to a *generic* plan (by default, after 5
+    executions) it no longer has a concrete parameter value to compare --
+    a bound `%s` for the key would silently stop using the index from
+    then on. Only the comparison value is a bound parameter.
+    """
+
+    _OPERATORS = {
+        filters.EQ: "=",
+        filters.NE: "<>",
+        filters.GT: ">",
+        filters.GE: ">=",
+        filters.LT: "<",
+        filters.LE: "<=",
+        filters.Like: "LIKE",
+        filters.NotLike: "NOT LIKE",
+        filters.Is: "IS NOT DISTINCT FROM",
+        filters.IsNot: "IS DISTINCT FROM",
+    }
+
+    def __init__(self, column_sql, key, clause_type, raw_value, cast):
+        if clause_type not in self._OPERATORS:
+            raise ValueError(
+                "JSONFields does not support clause %s for key %r" % (clause_type, key)
+            )
+        self._column_sql = column_sql
+        self._key = key
+        self._clause_type = clause_type
+        self._raw_value = raw_value
+        self._cast = cast
+
+    @property
+    def value(self):
+        return [self._raw_value]
+
+    def construct_expression(self):
+        escaped_key = self._key.replace("'", "''")
+        path = f"({self._column_sql}->>'{escaped_key}')"
+        if self._cast:
+            path = f"{path}::{self._cast}"
+        return f"{path} {self._OPERATORS[self._clause_type]} %s"
+
+
+class PostgreSqlJSONFields(ClauseList):
+    """AND of per-key comparisons against paths inside a jsonb column.
+
+    Compiles ``JSONFields({"kind": "foo", "value": GT(10)})`` on column
+    ``spec`` to roughly
+    ``(spec->>'kind') = %s AND (spec->>'value')::bigint > %s`` -- per-key
+    ``->>`` extraction (+ cast where the value isn't text), not a single
+    ``@>`` containment check. That's what lets it express ranges
+    (GT/GE/LT/LE), not just equality.
+
+    Indexing recipe for a "kind" column (verified with EXPLAIN ANALYZE
+    against a 2M-row jsonb table, see restalchemy issue #133):
+
+    This clause is meant for the common polymorphic-JSON shape where a
+    column always carries a discriminator key (conventionally "kind") plus
+    a handful of extra keys whose *presence and meaning are private to that
+    kind* -- e.g. ``{"kind": "totp", "period": 30}`` vs.
+    ``{"kind": "yubiotp", "device_id": "..."}`` in the same column. Two
+    different index shapes are needed, for two different query shapes:
+
+      1. **Always add one plain expression index on the discriminator
+         itself**, regardless of what else you index -- it's what every
+         query touching this column filters by first, it's the same for
+         every kind, and it's cheap (one text value per row)::
+
+             CREATE INDEX ix_t_spec_kind ON t ((spec->>'kind'));
+
+      2. **For each (kind, field) pair you actually query by, add a
+         *partial* expression index scoped to that kind** -- not a
+         table-wide index on the field name. Because the field's meaning
+         (and its presence at all) is specific to one kind, a table-wide
+         index would carry rows from every other kind for nothing, and
+         still couldn't be reused across kinds since the cast may differ
+         per kind too::
+
+             CREATE INDEX ix_t_spec_totp_period ON t (((spec->>'period')::bigint))
+                 WHERE spec->>'kind' = 'totp';
+
+         In testing, a query combining the discriminator with a per-kind
+         field (``kind = 'foo' AND value > 10``) was ~2x faster with this
+         partial index than with only the plain discriminator index from
+         (1), and a pure discriminator-only query against a *single* partial
+         index (no other predicate) served as an index-only scan ~9x faster
+         than the plain discriminator index -- Postgres can use a partial
+         index's own WHERE clause as proof of the predicate, no extra
+         condition needed. If you filter by more than one field of the same
+         kind together, put them in one composite partial index rather than
+         one index per field::
+
+             CREATE INDEX ix_t_spec_totp_period_active
+                 ON t (((spec->>'period')::bigint), (spec->>'active'))
+                 WHERE spec->>'kind' = 'totp';
+
+      Do **not** build a partial index for every (kind, field) combination
+      that merely *exists* in the schema -- each one is pure write overhead
+      until a query actually needs it. Add them lazily, driven by real
+      query patterns, the same way you'd add any other index.
+
+      * The cast in the index must match ``_JSON_SCALAR_CASTS`` exactly
+        (e.g. ``::bigint`` for a Python ``int``) -- Postgres only uses an
+        expression index when the query expression is syntactically
+        identical to the index definition, casts included. A cast mismatch
+        doesn't error, it just silently falls back to a seq/bitmap scan of
+        the whole column -- this bit us during testing (a hand-written
+        ``::int`` index was ignored by a query compiled with ``::bigint``).
+
+      * A GIN index (``USING gin(spec)`` / ``gin(spec jsonb_path_ops)``)
+        does NOT speed up anything generated here: GIN accelerates
+        ``@>``/``?``/``?|``/``?&``, not ``->>`` comparisons, and in testing
+        was sometimes *slower* than a plain seq scan at moderate (~20%)
+        selectivity. Only add GIN if something else in the app genuinely
+        queries with raw containment -- it also isn't free on writes:
+        pending-list flushes add write-latency spikes on jsonb columns that
+        are updated often.
+
+      * ``->>`` returns SQL NULL both when the key is absent and when its
+        JSON value is JSON ``null``; ``Is``/``IsNot`` (and ``EQ``/``NE``
+        with a ``None`` value, downgraded to them below for the same
+        NULL-safety reason as the top-level filters) can't tell these
+        apart.
+    """
+
+    operator = "AND"
+
+    def __init__(self, column, value_type, value, session):
+        column_sql = (
+            column.compile() if isinstance(column, common.ColumnFullPath) else column
+        )
+        clauses = []
+        for key, clause in value.items():
+            raw_value = clause.value
+            clause_type = type(clause)
+            if raw_value is None and clause_type in (filters.EQ, filters.NE):
+                clause_type = filters.Is if clause_type is filters.EQ else filters.IsNot
+            cast = _JSON_SCALAR_CASTS.get(type(raw_value))
+            clauses.append(
+                _JSONFieldClause(column_sql, key, clause_type, raw_value, cast)
+            )
+        super().__init__(*clauses)
+
+
 FILTER_MAPPING = {
     "mysql": {
         filters.EQ: EQ,
@@ -244,6 +409,7 @@ FILTER_MAPPING = {
         filters.NotLike: NotLike,
         filters.ContainsAll: PostgreSqlContainsAll,
         filters.ContainsAny: PostgreSqlContainsAny,
+        filters.JSONFields: PostgreSqlJSONFields,
     },
 }
 

--- a/restalchemy/tests/unit/dm/test_filters.py
+++ b/restalchemy/tests/unit/dm/test_filters.py
@@ -99,3 +99,44 @@ class ContainsAnyFilterTestCase(base.BaseTestCase):
     def test_repr(self):
         f = filters.ContainsAny(["x"])
         self.assertIn("ContainsAny", repr(f))
+
+
+class JSONFieldsFilterTestCase(base.BaseTestCase):
+    def test_plain_scalar_becomes_eq(self):
+        f = filters.JSONFields({"kind": "foo"})
+
+        self.assertEqual({"kind": filters.EQ("foo")}, f.value)
+
+    def test_explicit_clause_is_kept_as_is(self):
+        f = filters.JSONFields({"value": filters.GT(10)})
+
+        self.assertEqual({"value": filters.GT(10)}, f.value)
+
+    def test_mixed_fields(self):
+        f = filters.JSONFields({"kind": "foo", "value": filters.GT(10)})
+
+        self.assertEqual({"kind": filters.EQ("foo"), "value": filters.GT(10)}, f.value)
+
+    def test_equal(self):
+        self.assertEqual(
+            filters.JSONFields({"kind": "foo"}), filters.JSONFields({"kind": "foo"})
+        )
+
+    def test_not_equal_value(self):
+        self.assertNotEqual(
+            filters.JSONFields({"kind": "foo"}), filters.JSONFields({"kind": "bar"})
+        )
+
+    def test_and_expression_value_raises(self):
+        self.assertRaises(
+            ValueError,
+            filters.JSONFields,
+            {"kind": filters.AND({"a": filters.EQ(1)})},
+        )
+
+    def test_or_expression_value_raises(self):
+        self.assertRaises(
+            ValueError,
+            filters.JSONFields,
+            {"kind": filters.OR({"a": filters.EQ(1)})},
+        )

--- a/restalchemy/tests/unit/storage/sql/test_filters.py
+++ b/restalchemy/tests/unit/storage/sql/test_filters.py
@@ -15,6 +15,7 @@
 #    under the License.
 
 import collections
+import decimal
 from unittest import mock
 import uuid
 
@@ -549,6 +550,112 @@ class PostgreSqlContainsAnyConvertFiltersTestCase(base.BaseTestCase):
         )
         self.assertEqual('"tags" && %s', processed.construct_expression())
         self.assertEqual([["env:prod", "env:staging"]], processed.value)
+
+
+class JSONFieldModel(models.Model):
+    spec = properties.property(types.Dict(), default=dict)
+
+
+class JSONFieldsConvertFiltersTestCase(base.BaseTestCase):
+    def test_single_key_equality(self):
+        processed = filters.convert_filters(
+            JSONFieldModel,
+            {"spec": dm_filters.JSONFields({"kind": "foo"})},
+            session=_PostgreSqlSessionFixture(),
+        )
+        self.assertEqual(
+            "(\"spec\"->>'kind') = %s",
+            processed.construct_expression(),
+        )
+        self.assertEqual(["foo"], processed.value)
+
+    def test_range_on_int_value_adds_bigint_cast(self):
+        processed = filters.convert_filters(
+            JSONFieldModel,
+            {"spec": dm_filters.JSONFields({"value": dm_filters.GT(10)})},
+            session=_PostgreSqlSessionFixture(),
+        )
+        self.assertEqual(
+            "(\"spec\"->>'value')::bigint > %s",
+            processed.construct_expression(),
+        )
+        self.assertEqual([10], processed.value)
+
+    def test_range_on_decimal_value_adds_numeric_cast(self):
+        processed = filters.convert_filters(
+            JSONFieldModel,
+            {
+                "spec": dm_filters.JSONFields(
+                    {"price": dm_filters.GT(decimal.Decimal("9.99"))}
+                )
+            },
+            session=_PostgreSqlSessionFixture(),
+        )
+        self.assertEqual(
+            "(\"spec\"->>'price')::numeric > %s",
+            processed.construct_expression(),
+        )
+        self.assertEqual([decimal.Decimal("9.99")], processed.value)
+
+    def test_multiple_keys_are_anded_value_order_preserved(self):
+        d = collections.OrderedDict()
+        d["kind"] = "foo"
+        d["value"] = dm_filters.GT(10)
+        processed = filters.convert_filters(
+            JSONFieldModel,
+            {"spec": dm_filters.JSONFields(d)},
+            session=_PostgreSqlSessionFixture(),
+        )
+        self.assertEqual(
+            "((\"spec\"->>'kind') = %s AND (\"spec\"->>'value')::bigint > %s)",
+            processed.construct_expression(),
+        )
+        self.assertEqual(["foo", 10], processed.value)
+
+    def test_bool_value_gets_boolean_cast(self):
+        processed = filters.convert_filters(
+            JSONFieldModel,
+            {"spec": dm_filters.JSONFields({"active": True})},
+            session=_PostgreSqlSessionFixture(),
+        )
+        self.assertEqual(
+            "(\"spec\"->>'active')::boolean = %s",
+            processed.construct_expression(),
+        )
+        self.assertEqual([True], processed.value)
+
+    def test_none_value_downgrades_to_null_safe_is(self):
+        processed = filters.convert_filters(
+            JSONFieldModel,
+            {"spec": dm_filters.JSONFields({"label": None})},
+            session=_PostgreSqlSessionFixture(),
+        )
+        self.assertEqual(
+            "(\"spec\"->>'label') IS NOT DISTINCT FROM %s",
+            processed.construct_expression(),
+        )
+        self.assertEqual([None], processed.value)
+
+    def test_unsupported_clause_raises(self):
+        self.assertRaises(
+            ValueError,
+            filters.convert_filters,
+            JSONFieldModel,
+            {"spec": dm_filters.JSONFields({"tags": dm_filters.In([1, 2])})},
+            session=_PostgreSqlSessionFixture(),
+        )
+
+    def test_key_with_single_quote_is_escaped_not_injected(self):
+        processed = filters.convert_filters(
+            JSONFieldModel,
+            {"spec": dm_filters.JSONFields({"a'; DROP TABLE t; --": "x"})},
+            session=_PostgreSqlSessionFixture(),
+        )
+        self.assertEqual(
+            "(\"spec\"->>'a''; DROP TABLE t; --') = %s",
+            processed.construct_expression(),
+        )
+        self.assertEqual(["x"], processed.value)
 
 
 class ConvertFiltersTestCase(base.BaseTestCase):


### PR DESCRIPTION
Lets get_all()/get_one() filter on keys nested inside a jsonb column, including ranges (GT/LT/...) via ->> extraction with a per-Python-type cast, not just equality via containment. Documents the indexing recipe for the common kind-discriminated jsonb pattern (plain expression index on the discriminator, partial expression index per (kind, field)) both in the SQL clause docstring and in docs/en/reference/dm/filters.md, based on EXPLAIN ANALYZE measurements against a 2M-row table.