### PR TITLE
Fix PostgreSQL CLI help rendering

### DIFF
--- a/restalchemy/common/config_opts.py
+++ b/restalchemy/common/config_opts.py
@@ -155,7 +155,7 @@ def register_postgresql_db_opts(
                 "The maximum lifetime of a connection in the pool, in"
                 " seconds. Connections used for longer get closed and"
                 " replaced by a new one. The amount is reduced by a"
-                " random 10% to avoid mass eviction."
+                " random 10%% to avoid mass eviction."
             ),
         ),
         cfg.FloatOpt(

--- a/restalchemy/tests/unit/common/test_config_opts.py
+++ b/restalchemy/tests/unit/common/test_config_opts.py
@@ -1,0 +1,37 @@
+#    Copyright 2026 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import contextlib
+import io
+import unittest
+
+from oslo_config import cfg
+
+from restalchemy.common import config_opts
+
+
+class TestPostgresqlConfigOpts(unittest.TestCase):
+    def test_help_renders_literal_percent(self):
+        conf = cfg.ConfigOpts()
+        config_opts.register_postgresql_db_opts(conf)
+        stdout = io.StringIO()
+
+        with contextlib.redirect_stdout(stdout):
+            with self.assertRaises(SystemExit) as exc:
+                conf(["--help"])
+
+        self.assertEqual(0, exc.exception.code)
+        self.assertIn("random 10% to avoid mass eviction", stdout.getvalue())


### PR DESCRIPTION
## Summary

- escape the literal percent sign in connection_max_lifetime help so oslo.config can render --help
- cover PostgreSQL option registration with a regression test

## Validation

- git diff --check
- automated test suite runs in CI

Closes #131