### PR TITLE
Bump pytest-xdist workers from 10 to 16

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ passenv =
   functional: MYSQL_DATABASE
   functional: DATABASE_URI
 commands =
-  coverage run -p -m pytest {posargs} --timer-top-n=10 -n 10 {env:TEST_PATH}
+  coverage run -p -m pytest {posargs} --timer-top-n=10 -n 16 {env:TEST_PATH}
 
 [testenv:begin]
 runner = uv-venv-lock-runner


### PR DESCRIPTION
Benchmarked -n on a 128-core box, ascending until time started growing again:
- unit (559 tests): minimum at n=4 (1.51s), monotonically worse past n=6 (n=32 -> 2.90s)
- functional (222 tests, MySQL-backed): minimum at n=16 (36.8s), worse below (n=10 -> 39.2s) and above (n=32 -> 50.3s)

16 is close to optimal for functional and clearly better than 10 for it, while still reasonable for the much smaller unit suite.