### PR TITLE
Fix OpenAPI schema property mutation

### DIFF
--- a/restalchemy/api/resources.py
+++ b/restalchemy/api/resources.py
@@ -534,7 +534,9 @@ class AbstractResource(metaclass=abc.ABCMeta):
 
     def get_prop_kwargs(self, name, openapi_version):
         try:
-            kwargs = self.get_model().properties.properties[name].get_kwargs()
+            kwargs = dict(
+                self.get_model().properties.properties[name].get_kwargs()
+            )
         except KeyError:
             kwargs = {}
         kwargs["openapi"] = openapi_version

--- a/restalchemy/tests/unit/api/test_resources.py
+++ b/restalchemy/tests/unit/api/test_resources.py
@@ -54,6 +54,22 @@ class FakeEmptyFieldsRoleContext(object):
     roles = ["empty_fields"]
 
 
+class ResourceSchemaGenerationTestCase(unittest.TestCase):
+    def tearDown(self):
+        super(ResourceSchemaGenerationTestCase, self).tearDown()
+        resources.ResourceMap.model_type_to_resource = {}
+
+    def test_schema_generation_does_not_mutate_model_property_kwargs(self):
+        resource = resources.ResourceByRAModel(FakeModel)
+        property_creator = FakeModel.properties.properties["standard_field1"]
+        original_kwargs = dict(property_creator.get_kwargs())
+
+        resource.generate_schema_object(constants.GET, "3.0.3")
+
+        self.assertEqual(original_kwargs, property_creator.get_kwargs())
+        FakeModel()
+
+
 # NOTE(efrolov): Interface tests
 class ResourceByRAModelHiddenFieldsInterfacesTestCase(unittest.TestCase):
     def tearDown(self):


### PR DESCRIPTION
## Summary

- copy model property keyword arguments before adding OpenAPI-only metadata
- keep schema generation side-effect free
- add a regression test that constructs the model after generating its schema

Closes #142.

## Verification

- `uv run pytest -q --timer-top-n=10 restalchemy/tests/unit` (562 passed, 2 skipped)
- `uv run ruff check .`
