### PR TITLE
Fix route OpenAPI property kwargs mutation

### DIFF
--- a/restalchemy/openapi/utils.py
+++ b/restalchemy/openapi/utils.py
@@ -38,7 +38,9 @@ class ResourceSchemaGenerator(object):
 
     def get_prop_kwargs(self, name):
         try:
-            kwargs = self._resource.get_model().properties.properties[name].get_kwargs()
+            kwargs = dict(
+                self._resource.get_model().properties.properties[name].get_kwargs()
+            )
         except KeyError:
             kwargs = {}
         kwargs["openapi"] = self._openapi_version

--- a/restalchemy/tests/unit/api/test_resources.py
+++ b/restalchemy/tests/unit/api/test_resources.py
@@ -23,6 +23,7 @@ from restalchemy.api import resources
 from restalchemy.dm import models
 from restalchemy.dm import properties
 from restalchemy.dm import types
+from restalchemy.openapi import utils as openapi_utils
 
 
 class FakeModel(models.CustomPropertiesMixin, models.ModelWithUUID):
@@ -65,6 +66,21 @@ class ResourceSchemaGenerationTestCase(unittest.TestCase):
         original_kwargs = dict(property_creator.get_kwargs())
 
         resource.generate_schema_object(constants.GET, "3.0.3")
+
+        self.assertEqual(original_kwargs, property_creator.get_kwargs())
+        FakeModel()
+
+    def test_route_schema_generation_does_not_mutate_property_kwargs(self):
+        resource = resources.ResourceByRAModel(FakeModel)
+        generator = openapi_utils.ResourceSchemaGenerator(
+            resource,
+            route=None,
+            openapi_version="3.0.3",
+        )
+        property_creator = FakeModel.properties.properties["standard_field1"]
+        original_kwargs = dict(property_creator.get_kwargs())
+
+        generator.get_prop_kwargs("standard_field1")
 
         self.assertEqual(original_kwargs, property_creator.get_kwargs())
         FakeModel()


### PR DESCRIPTION
## Summary

- copy model property kwargs before adding route-specific OpenAPI metadata
- cover the `ResourceSchemaGenerator` path that remained mutable after #143
- keep runtime model construction independent of OpenAPI generation order

Fixes #144.

## Verification

- `tox -e py314` — 563 passed, 2 skipped
- `tox -e ruff-check`
- Workspace consumer regression suite — 63 passed with the patched RestAlchemy checkout