### PR TITLE
Refuse hidden fields in filters a resource does not process

### DIFF
--- a/restalchemy/api/controllers.py
+++ b/restalchemy/api/controllers.py
@@ -275,6 +275,34 @@ class Controller(object):
         self._filter_fields[param_name] = field
         return field
 
+    def _reject_hidden_filter_field(self, param_name):
+        """Refuse a parameter naming a field this request may not see.
+
+        `_resolve_filter_field` settles this for a resource that processes
+        filters. One that does not never reached it: the parameter was
+        handed to `filter()` exactly as it arrived, so a hidden field could
+        be filtered by as readily as a visible one. `?password_hash=x`
+        narrowing the collection reports on the field one guess at a time,
+        which is what hiding it was meant to prevent -- and hiding is not a
+        statement about how the resource parses values.
+
+        Unlike the resolving path, a name that is not a field of this
+        resource passes silently. That is the point of not processing
+        filters: a controller may take query parameters of its own and read
+        them in its own `filter()`, and those are not the resource's to
+        judge.
+        """
+        if self.__resource__ is None or self.model is None:
+            return
+        try:
+            field = self.__resource__.get_field(
+                self.__resource__.get_model_field_name(param_name)
+            )
+        except ValueError:
+            return
+        if not self._is_queryable_field(field.name):
+            raise exc.ValidationFilterIncompatibleError(val=param_name)
+
     def _prepare_filter(self, param_name, value):
         resource_field = self._resolve_filter_field(param_name)
 
@@ -393,9 +421,11 @@ class Controller(object):
         result = {}
         process = self.__resource__ and self.__resource__.is_process_filters()
         for param, value in params.items():
-            filter_name, filter_value = (
-                self._prepare_filter(param, value) if process else (param, value)
-            )
+            if process:
+                filter_name, filter_value = self._prepare_filter(param, value)
+            else:
+                self._reject_hidden_filter_field(param)
+                filter_name, filter_value = param, value
             current = result.get(filter_name)
             if current is None:
                 result[filter_name] = dm_filters.EQ(filter_value)

--- a/restalchemy/tests/unit/api/test_controllers.py
+++ b/restalchemy/tests/unit/api/test_controllers.py
@@ -455,6 +455,30 @@ class UnfilterableFieldController(controllers.BaseResourceController):
     )
 
 
+class RawHiddenFieldController(controllers.BaseResourceController):
+    """Hides a field on a resource that does not process filters."""
+
+    __resource__ = resources.ResourceByRAModel(
+        SecretModel,
+        hidden_fields=["password_hash"],
+    )
+
+
+class RawUnfilterableFieldController(controllers.BaseResourceController):
+    """Hides a field for FILTER only, again without processing filters."""
+
+    __resource__ = resources.ResourceByRAModel(
+        SecretModel,
+        fields_permissions=field_permissions.FieldsPermissions(
+            fields={
+                "token": {
+                    controllers.constants.FILTER: field_permissions.Permissions.HIDDEN
+                }
+            },
+        ),
+    )
+
+
 class UnderscoreController(controllers.BaseResourceController):
     __resource__ = resources.ResourceByRAModel(
         SecretModel,
@@ -810,6 +834,64 @@ class HiddenFieldParameterTestCase(unittest.TestCase):
         self.assertEqual(
             {"name": dm_filters.EQ("victim")},
             self._filters(HiddenFieldController, "name=victim"),
+        )
+
+
+class HiddenFieldParameterWithoutProcessingTestCase(unittest.TestCase):
+    """The same question on a resource that does not process filters.
+
+    `process_filters` turns on parsing a value into the field's type.
+    Whether the field may be named at all is a different question, and the
+    answer to it used to depend on the flag: without it the parameter went
+    to `filter()` exactly as it arrived, hidden field or not.
+    """
+
+    def _filters(self, controller_class, query):
+        controller = controller_class(_request(query))
+        return controller._prepare_filters(
+            controller._req.api_context.get_params_filters(),
+        )
+
+    def test_a_hidden_field_parameter_is_refused(self):
+        self.assertRaises(
+            ra_exc.ValidationFilterIncompatibleError,
+            self._filters,
+            RawHiddenFieldController,
+            "password_hash=x",
+        )
+
+    def test_a_field_hidden_for_filtering_only_is_refused(self):
+        self.assertRaises(
+            ra_exc.ValidationFilterIncompatibleError,
+            self._filters,
+            RawUnfilterableFieldController,
+            "token=x",
+        )
+
+    def test_a_hidden_field_is_refused_under_its_api_name(self):
+        # The resource converts underscores, so this is the name the field
+        # is addressed by from outside.
+        self.assertRaises(
+            ra_exc.ValidationFilterIncompatibleError,
+            self._filters,
+            RawHiddenFieldController,
+            "password-hash=x",
+        )
+
+    def test_a_visible_field_parameter_arrives_unparsed(self):
+        # Which is what not processing filters means, and is unchanged.
+        self.assertEqual(
+            {"name": dm_filters.EQ("victim")},
+            self._filters(RawHiddenFieldController, "name=victim"),
+        )
+
+    def test_a_parameter_naming_no_field_is_left_alone(self):
+        # A controller that does not process filters may take query
+        # parameters of its own and read them in its own filter(); those
+        # are not the resource's to judge.
+        self.assertEqual(
+            {"since": dm_filters.EQ("yesterday")},
+            self._filters(RawHiddenFieldController, "since=yesterday"),
         )
 
 


### PR DESCRIPTION
Whether a query parameter may name a field went through _resolve_filter_field, and only a resource with process_filters reached it. Without the flag the parameter was handed to filter() exactly as it arrived, so on such a resource -- which is the default -- a hidden field was filterable:

    ?password_hash=x   ->  {"password_hash": EQ("x")}  ->  WHERE ...

The collection narrowing or not answers for the field one guess at a time, which is the first half of what hiding it was meant to prevent. Sorting has been resolving its key regardless of the flag since it started refusing hidden ones, so the two disagreed about the same field.

process_filters says the resource parses a value into the field's type. It says nothing about which fields exist or who may see them, so the visibility check no longer hangs off it.

A name that is not a field of the resource still passes through untouched, and deliberately: not processing filters is how a controller takes query parameters of its own and reads them in its own filter(). Those are not the resource's to judge, and refusing them here would break controllers that do exactly this. An unknown *field* name therefore still reaches storage and still fails there, as before -- that is a separate defect, and fixing it here would take the same pass-through with it.