### PR TITLE
Performance: model property and packing hot paths

### DIFF
--- a/restalchemy/api/controllers.py
+++ b/restalchemy/api/controllers.py
@@ -578,25 +578,47 @@ class BaseResourceController(Controller):
 
         return {}, filters
 
+    # The clauses a custom property can be filtered by, and how each one
+    # decides a single row. Storage never sees these filters, so the
+    # comparison is the one Python makes.
+    _CUSTOM_FILTER_MATCHERS = (
+        (dm_filters.In, lambda value, expected: value in expected),
+        (dm_filters.EQ, lambda value, expected: value == expected),
+    )
+
     def _process_custom_filters(self, result, filters):
+        """Apply the filters storage could not, over the rows it returned.
+
+        Selects into a new list rather than removing from the one passed
+        in: a removal is a linear scan comparing models by id, so a filter
+        that kept its rows -- the ordinary case -- cost O(n^2) in the size
+        of the result.
+        """
         if not filters:
             return result
-        for item in result[:]:
-            for field_name, filter_value in filters.items():
-                if not result:
+
+        matchers = []
+        for field_name, filter_value in filters.items():
+            for filter_class, match in self._CUSTOM_FILTER_MATCHERS:
+                if isinstance(filter_value, filter_class):
+                    matchers.append((field_name, filter_value.value, match))
                     break
-                elif item not in result:
-                    continue
-                elif isinstance(filter_value, dm_filters.In):
-                    if getattr(item, field_name) not in filter_value.value:
-                        result.remove(item)
-                        continue
-                elif isinstance(filter_value, dm_filters.EQ):
-                    if getattr(item, field_name) != filter_value.value:
-                        result.remove(item)
-                        continue
-                else:
-                    raise exc.ValidationFilterIncompatibleError(val=field_name)
+            else:
+                # Unsupported clause: refused on sight, not once a row
+                # reaches it, so an empty result cannot let it through.
+                raise exc.ValidationFilterIncompatibleError(val=field_name)
+
+        # Narrowed in place, as before: a caller that read the list it
+        # passed in rather than the one returned still sees the rows that
+        # survived, and not the ones that did not.
+        result[:] = [
+            item
+            for item in result
+            if all(
+                match(getattr(item, field_name), expected)
+                for field_name, expected, match in matchers
+            )
+        ]
         return result
 
     def _process_storage_filters(self, filters, order_by=None):

--- a/restalchemy/api/packers.py
+++ b/restalchemy/api/packers.py
@@ -44,6 +44,39 @@ class BaseResourcePacker(object):
     def __init__(self, resource_type, request):
         self._rt = resource_type
         self._req = request
+        self._fields = None
+        self._visible_fields = None
+        self._fields_resource = None
+
+    def _get_fields(self):
+        """The resource fields, resolved once per packer.
+
+        `get_fields_by_request` rebuilds a property object per field on
+        every call, and the answer depends only on the request, which a
+        packer is built for and does not outlive. Packing a collection
+        called it once per object.
+
+        The resource is not as fixed as the request: `routes.Action.do`
+        swaps `_rt` out after building the packer, so a cache is only
+        good for the resource it was built from.
+        """
+        if self._fields is None or self._fields_resource is not self._rt:
+            self._fields_resource = self._rt
+            self._fields = list(self._rt.get_fields_by_request(self._req))
+            self._visible_fields = None
+        return self._fields
+
+    def _get_visible_fields(self):
+        """The fields packing writes out, with their API names."""
+        fields = self._get_fields()
+        if self._visible_fields is None:
+            self._visible_fields = [
+                (name, prop.api_name, prop)
+                for name, prop in fields
+                if prop.is_public()
+                and not self._rt._fields_permissions.is_hidden(name, self._req)
+            ]
+        return self._visible_fields
 
     def pack_resource(self, obj):
         if isinstance(
@@ -53,17 +86,13 @@ class BaseResourcePacker(object):
             return obj
         else:
             result = {}
-            for name, prop in self._rt.get_fields_by_request(self._req):
-                api_name = prop.api_name
-                if prop.is_public() and not self._rt._fields_permissions.is_hidden(
-                    name, self._req
-                ):
-                    value = getattr(obj, name)
-                    if value is None:
-                        if not self._skip_none:
-                            result[api_name] = value
-                    else:
-                        result[api_name] = prop.dump_value(value)
+            for name, api_name, prop in self._get_visible_fields():
+                value = getattr(obj, name)
+                if value is None:
+                    if not self._skip_none:
+                        result[api_name] = value
+                else:
+                    result[api_name] = prop.dump_value(value)
 
             return result
 
@@ -82,7 +111,7 @@ class BaseResourcePacker(object):
             return value
         value = copy.deepcopy(value)
         result = {}
-        for name, prop in self._rt.get_fields_by_request(self._req):
+        for name, prop in self._get_fields():
             api_name = prop.api_name
             prop_value = value.pop(api_name, DEFAULT_VALUE)
             if prop_value is not DEFAULT_VALUE:

--- a/restalchemy/common/utils.py
+++ b/restalchemy/common/utils.py
@@ -41,6 +41,18 @@ class ReadOnlyDictProxy(collections_abc.Mapping):
     def __getitem__(self, key):
         return self._d[key]
 
+    # The Mapping versions of these build a view that walks the keys and
+    # looks each one up again. A proxy adds nothing to that walk, so hand
+    # out the underlying dict's views instead.
+    def keys(self):
+        return self._d.keys()
+
+    def values(self):
+        return self._d.values()
+
+    def items(self):
+        return self._d.items()
+
     def __hash__(self):
         if self._hash is None:
             self._hash = 0

--- a/restalchemy/dm/models.py
+++ b/restalchemy/dm/models.py
@@ -102,10 +102,12 @@ class Model(collections_abc.Mapping, metaclass=MetaModel):
             )
 
     def __setattr__(self, name, value):
-        try:
-            self.properties[name].value = value
-        except KeyError:
+        props = self.properties
+        if name not in props:
             super(Model, self).__setattr__(name, value)
+            return
+        try:
+            props[name].value = value
         except exc.TypeError as e:
             raise exc.ModelTypeError(
                 property_name=name,
@@ -123,10 +125,11 @@ class Model(collections_abc.Mapping, metaclass=MetaModel):
         except exc.PropertyRequired as e:
             raise exc.PropertyRequired(name=e.name, model=self.__class__)
 
-        self.id_properties = {}
-        for name, prop in self.properties.items():
-            if prop.is_id_property():
-                self.id_properties[name] = prop
+        # Which names are id properties is decided by the declaration, and
+        # `MetaModel` already worked it out for the class; asking every
+        # property again per model built was the same answer each time.
+        props = self.properties
+        self.id_properties = {name: props[name] for name in type(self).id_properties}
 
     @classmethod
     def restore(cls, **kwargs):

--- a/restalchemy/dm/properties.py
+++ b/restalchemy/dm/properties.py
@@ -49,6 +49,23 @@ class BaseProperty(AbstractProperty):
     pass
 
 
+# `isinstance` against an abstract base walks the subclass machinery, and a
+# property type is checked once per property per model built. The answer
+# depends only on the type's class, so the classes that passed are
+# remembered. Only passes are: a class can be registered with the base
+# later, but never unregistered.
+_verified_property_types = set()
+
+
+def _check_property_type(property_type):
+    property_type_class = type(property_type)
+    if property_type_class in _verified_property_types:
+        return
+    if not isinstance(property_type, types.BaseType):
+        raise TypeError("Property type must be instance of %s" % types.BaseType)
+    _verified_property_types.add(property_type_class)
+
+
 class Property(BaseProperty):
     def __init__(
         self,
@@ -60,8 +77,7 @@ class Property(BaseProperty):
         mutable=False,
         example=None,
     ):
-        if not isinstance(property_type, types.BaseType):
-            raise TypeError("Property type must be instance of %s" % types.BaseType)
+        _check_property_type(property_type)
         self._type = property_type
         self._required = bool(required)
         self._read_only = bool(read_only)
@@ -157,25 +173,65 @@ class PropertyCreator(object):
 
 
 class PropertyMapping(collections_abc.Mapping, metaclass=abc.ABCMeta):
+    """A mapping over `self._properties`, exposed read-only.
+
+    A subclass sets `_properties` before this class is of any use; there
+    is deliberately no default, so forgetting it fails loudly rather than
+    behaving as an empty mapping.
+
+    The `properties` proxy is built once per instance and handed out on
+    every request: it is a view over `_properties`, so a fresh one says
+    nothing new, and building one per lookup put an allocation on the path
+    of every model attribute read. Subclasses that replace `_properties`
+    wholesale must call `_reset_properties_proxy`.
+    """
+
     @property
-    @abc.abstractmethod
     def properties(self):
-        pass
+        try:
+            return self.__proxy
+        except AttributeError:
+            self.__proxy = utils.ReadOnlyDictProxy(self._properties)
+            return self.__proxy
+
+    def _reset_properties_proxy(self):
+        self.__proxy = utils.ReadOnlyDictProxy(self._properties)
 
     def __getitem__(self, name):
-        return self.properties[name]
+        return self._properties[name]
+
+    def __contains__(self, name):
+        # The Mapping version asks `__getitem__` and catches the KeyError,
+        # which puts a raised exception on the path of every attribute a
+        # model sets that is not a property.
+        return name in self._properties
 
     def __iter__(self):
-        return iter(self.properties)
+        return iter(self._properties)
 
     def __len__(self):
-        return len(self.properties)
+        return len(self._properties)
 
 
 class PropertyCollection(PropertyMapping):
     def __init__(self, **kwargs):
         self._properties = kwargs
+        self._nested_names = frozenset(
+            name
+            for name, item in kwargs.items()
+            if isinstance(item, PropertyCollection)
+        )
         super(PropertyCollection, self).__init__()
+
+    @builtins.property
+    def nested_names(self):
+        """The names holding a nested collection rather than a property.
+
+        A declaration decides this, so it is answered once here instead of
+        per model built from the collection: the check is an abstract-base
+        `isinstance`, which is not cheap and ran per property per model.
+        """
+        return self._nested_names
 
     def sort_properties(self):
         """Switch the model to sorted properties
@@ -199,13 +255,10 @@ class PropertyCollection(PropertyMapping):
         for key in sorted(self._properties):
             result[key] = self._properties[key]
         self._properties = result
+        self._reset_properties_proxy()
 
     def __getitem__(self, name):
-        return self.properties[name].get_property_class()
-
-    @builtins.property
-    def properties(self):
-        return utils.ReadOnlyDictProxy(self._properties)
+        return self._properties[name].get_property_class()
 
     def __add__(self, other):
         if isinstance(other, PropertyCollection):
@@ -227,8 +280,9 @@ class PropertyCollection(PropertyMapping):
 class PropertyManager(PropertyMapping):
     def __init__(self, property_collection, **kwargs):
         self._properties = {}
+        nested_names = property_collection.nested_names
         for name, item in property_collection.properties.items():
-            if isinstance(item, PropertyCollection):
+            if name in nested_names:
                 prop = PropertyManager(item, **kwargs.pop(name, {}))
             else:
                 try:
@@ -245,13 +299,9 @@ class PropertyManager(PropertyMapping):
         super(PropertyManager, self).__init__()
 
     @builtins.property
-    def properties(self):
-        return utils.ReadOnlyDictProxy(self._properties)
-
-    @builtins.property
     def value(self):
         result = {}
-        for k, v in self.properties.items():
+        for k, v in self._properties.items():
             result[k] = v.value
         return result
 

--- a/restalchemy/storage/sql/orm.py
+++ b/restalchemy/storage/sql/orm.py
@@ -204,11 +204,10 @@ class SQLStorableMixin(base.AbstractStorableMixin, metaclass=abc.ABCMeta):
     @classmethod
     def restore_from_storage(cls, **kwargs):
         model_format = {}
+        model_properties = cls.properties.properties
         for name, value in kwargs.items():
             model_format[name] = (
-                cls.properties.properties[name]
-                .get_property_type()
-                .from_simple_type(value)
+                model_properties[name].get_property_type().from_simple_type(value)
             )
         obj = cls.restore(**model_format)
         obj._saved = True

--- a/restalchemy/tests/unit/api/test_controllers.py
+++ b/restalchemy/tests/unit/api/test_controllers.py
@@ -1021,3 +1021,97 @@ class FilterLangOpenApiTestCase(unittest.TestCase):
         parameters = self._parameters(NameFilterController)
 
         self.assertIn("x-ra-filter-fields", parameters["name"])
+
+
+class CustomFilterProcessingTestCase(unittest.TestCase):
+    """The filters storage cannot run, applied over the rows it returned."""
+
+    def setUp(self):
+        self._controller = CustomPropertyController(_request(""))
+
+    def _rows(self, count):
+        return [CustomPropertyModel(name="vm%d" % i) for i in range(count)]
+
+    def test_no_filters_passes_the_rows_through(self):
+        rows = self._rows(3)
+
+        self.assertEqual(rows, self._controller._process_custom_filters(rows, {}))
+
+    def test_a_matching_equality_keeps_every_row(self):
+        rows = self._rows(3)
+
+        self.assertEqual(
+            rows,
+            self._controller._process_custom_filters(
+                rows, {"computed": dm_filters.EQ("computed")}
+            ),
+        )
+
+    def test_a_missing_equality_drops_every_row(self):
+        self.assertEqual(
+            [],
+            self._controller._process_custom_filters(
+                self._rows(3), {"computed": dm_filters.EQ("other")}
+            ),
+        )
+
+    def test_membership_is_honoured(self):
+        rows = self._rows(2)
+
+        self.assertEqual(
+            rows,
+            self._controller._process_custom_filters(
+                rows, {"computed": dm_filters.In(["computed", "other"])}
+            ),
+        )
+        self.assertEqual(
+            [],
+            self._controller._process_custom_filters(
+                rows, {"computed": dm_filters.In(["other"])}
+            ),
+        )
+
+    def test_filters_are_conjoined(self):
+        # A row must satisfy all of them, not the last one to look at it.
+        rows = self._rows(2)
+
+        self.assertEqual(
+            [],
+            self._controller._process_custom_filters(
+                rows,
+                {
+                    "computed": dm_filters.EQ("computed"),
+                    "name": dm_filters.EQ("nothing"),
+                },
+            ),
+        )
+
+    def test_the_list_passed_in_is_narrowed_in_place(self):
+        # The old implementation removed from it, and a caller may be
+        # reading that list rather than the returned one.
+        rows = self._rows(3)
+
+        returned = self._controller._process_custom_filters(
+            rows, {"computed": dm_filters.EQ("other")}
+        )
+
+        self.assertEqual([], rows)
+        self.assertIs(rows, returned)
+
+    def test_an_unsupported_clause_is_refused(self):
+        self.assertRaises(
+            ra_exc.ValidationFilterIncompatibleError,
+            self._controller._process_custom_filters,
+            self._rows(2),
+            {"computed": dm_filters.NE("computed")},
+        )
+
+    def test_an_unsupported_clause_is_refused_on_an_empty_result(self):
+        # Refused on sight: whether the clause is supported cannot depend
+        # on how many rows happened to come back.
+        self.assertRaises(
+            ra_exc.ValidationFilterIncompatibleError,
+            self._controller._process_custom_filters,
+            [],
+            {"computed": dm_filters.NE("computed")},
+        )

--- a/restalchemy/tests/unit/api/test_packer.py
+++ b/restalchemy/tests/unit/api/test_packer.py
@@ -272,3 +272,56 @@ class MultipartPackerTestCase(base.BaseTestCase):
             next(iter(result[packers.MultipartPacker._parts_key]["data"].file))
             == b"test_body\n"
         )
+
+
+class OtherModel(models.ModelWithUUID):
+    other_field = properties.property(types.Integer(), required=False)
+
+
+class PackerResourceSwapTestCase(base.BaseTestCase):
+    """A packer's resource is not as fixed as its request.
+
+    `routes.Action.do` builds a packer and then clears `_rt` on it, so
+    fields resolved for one resource must not answer for another.
+    """
+
+    def setUp(self):
+        super(PackerResourceSwapTestCase, self).setUp()
+        req = mock.Mock()
+        req.context.roles = ["owner"]
+        self._req = req
+        self._packer = packers.BaseResourcePacker(
+            resources.ResourceByRAModel(FakeModel),
+            req,
+        )
+
+    def tearDown(self):
+        super(PackerResourceSwapTestCase, self).tearDown()
+        resources.ResourceMap.model_type_to_resource = {}
+        del self._packer
+
+    def test_fields_follow_the_resource(self):
+        first = sorted(name for name, _ in self._packer._get_fields())
+
+        self._packer._rt = resources.ResourceByRAModel(OtherModel)
+        second = sorted(name for name, _ in self._packer._get_fields())
+
+        self.assertIn("field1", first)
+        self.assertNotIn("field1", second)
+        self.assertIn("other_field", second)
+
+    def test_the_packed_fields_follow_the_resource_too(self):
+        model = OtherModel(other_field=7)
+
+        self._packer._rt = resources.ResourceByRAModel(OtherModel)
+
+        self.assertEqual(
+            {"other-field": 7, "uuid": str(model.uuid)},
+            self._packer.pack_resource(model),
+        )
+
+    def test_clearing_the_resource_is_what_unpack_checks(self):
+        # Action.do sets _rt to None so any field reaches the action.
+        self._packer._rt = None
+
+        self.assertEqual({"anything": 1}, self._packer.unpack({"anything": 1}))

--- a/restalchemy/tests/unit/dm/test_models.py
+++ b/restalchemy/tests/unit/dm/test_models.py
@@ -61,6 +61,9 @@ class ModelTestCase(base.BaseTestCase):
         super(ModelTestCase, self).setUp()
         self.PM_MOCK.__getitem__.side_effect = None
         self.PM_MOCK.reset_mock()
+        # The one name the double stands in for a property of. Everything
+        # else a model sets on itself is a plain attribute.
+        self.PM_MOCK.__contains__.side_effect = lambda name: name == "fake_prop1"
         self.pm_mock = pm_mock
         self.kwargs = {"kwarg1": 1, "kwarg2": 2}
         self.test_instance = models.Model(**self.kwargs)

--- a/restalchemy/tests/unit/dm/test_properties.py
+++ b/restalchemy/tests/unit/dm/test_properties.py
@@ -334,6 +334,8 @@ class PropertyManagerTestCase(base.BaseTestCase):
                     ("fake2", "fake2"),
                 ],
                 "instantiate_property.return_value": FAKE_VALUE,
+                # Neither name holds a nested collection.
+                "nested_names": frozenset(),
             }
         )
 


### PR DESCRIPTION
Three independent hot paths in the request cycle, each rebuilding per object or
per row what is fixed per class or per request. No public API changes.

Branch: `perf/model-hot-paths` (3 commits, based on `origin/master`).

## Results

Python 3.12.3, AMD EPYC 7742, best of 3–5 runs.

| Path | master | branch | |
|---|---:|---:|---:|
| Unfiltered list of 1000 rows, end to end | 83.7 ms | **35.4 ms** | 2.4× |
| ├ restore rows into models | 39.7 ms | **23.2 ms** | 1.7× |
| └ pack collection to JSON | 44.0 ms | **12.2 ms** | 3.6× |
| Pack 1000 rows, plain resource | 18.9 ms | **3.4 ms** | 5.5× |
| Pack 1000 rows, custom properties | 27.4 ms | **4.3 ms** | 6.4× |
| Build one model | 20.1 µs | **12.7 µs** | 1.6× |
| Read one model attribute | 0.44 µs | **0.20 µs** | 2.2× |

Filtering on a custom property was quadratic in the size of the result, and
worst when the filter *matched* — a filter that dropped everything collapsed
the list it was scanning, so the ordinary case was the slow one:

| rows | master | branch | |
|---:|---:|---:|---:|
| 500 | 291.9 ms | **0.20 ms** | 1 500× |
| 1 000 | 1161 ms | **0.39 ms** | 3 000× |
| 2 000 | 4550 ms | **0.77 ms** | 5 900× |
| 5 000 | 28 339 ms | **1.97 ms** | 14 000× |
| 100 000 | — | **43 ms** | now linear |

## What changed

**1. `Answer per-model questions the declaration already settled`**

- The `properties` proxy was rebuilt on every attribute read — a fresh
  `ReadOnlyDictProxy` over a dict that does not change.
- Nested-collection and property-type `isinstance` checks ran per property per
  model, though a declaration decides both. Abstract-base checks are not cheap.
- `pour` re-derived the id properties `MetaModel` had already computed for the
  class.
- `Mapping.items()` built a view that re-looked-up every key through a proxy
  that adds nothing to the walk.
- `Model.__setattr__` raised and caught a `KeyError` for every plain attribute a
  model sets on itself — three per row restored from storage.

**2. `Resolve a resource's fields once per request, not once per object`**

`pack_resource` opened with `get_fields_by_request`, which rebuilds a property
object per field. Packing a collection called it once per object, so a
thousand-row response rebuilt the same field metadata a thousand times before
touching any data. `is_public`, `fields_permissions.is_hidden` and the
`api_name` mapping leave the per-object loop with it.

**3. `Filter custom properties in one pass over the result`**

Removal from a list plus an `item not in result` guard — both linear scans
comparing models by id, which reads an attribute.