### PR TITLE
Refuse writing `value` onto a property class

### DIFF
--- a/restalchemy/common/exceptions.py
+++ b/restalchemy/common/exceptions.py
@@ -125,6 +125,18 @@ class ReadOnlyProperty(PropertyException):
     message = "Property '%(name)s' of model %(model)s is read only."
 
 
+class PropertyClassAssignment(RestAlchemyException):
+    code = 500
+    message = (
+        "Refusing to write `value` onto a property class. This happens when a "
+        "model is built without its constructor — `Model.__new__(Model)` — so "
+        "it has no properties of its own and the assignment lands on the "
+        "shared declaration, changing that value for every property of every "
+        "model in the process. Build the model normally, or call `pour()` "
+        "first as `restore()` does."
+    )
+
+
 class TypeError(RestAlchemyException, TypeError):
     message = "Invalid type value '%(value)s' for '%(property_type)s'."
     code = 400

--- a/restalchemy/dm/properties.py
+++ b/restalchemy/dm/properties.py
@@ -26,7 +26,29 @@ from restalchemy.common import utils
 from restalchemy.dm import types
 
 
-class AbstractProperty(metaclass=abc.ABCMeta):
+class PropertyMeta(abc.ABCMeta):
+    """Refuses `value` written onto a property *class*.
+
+    A model built without its constructor has no properties of its own, so
+    `self.properties` is still the class's collection — and what that yields
+    for a name is the property *class*, not an instance of it. The write in
+    `Model.__setattr__` then lands on the class, where it shadows the `value`
+    descriptor for every property of every model in the process, including
+    objects created afterwards. Nothing raised, and the damage showed up
+    wherever somebody next read a model.
+
+    Checked here rather than in `Model.__setattr__` because here it is free:
+    this fires only on an assignment to a class object, which no working path
+    does, while a property write on an instance never reaches it.
+    """
+
+    def __setattr__(cls, name, value):
+        if name == "value":
+            raise exc.PropertyClassAssignment()
+        super().__setattr__(name, value)
+
+
+class AbstractProperty(metaclass=PropertyMeta):
     @property
     @abc.abstractmethod
     def value(self):

--- a/restalchemy/tests/unit/dm/test_models.py
+++ b/restalchemy/tests/unit/dm/test_models.py
@@ -301,3 +301,79 @@ class SimpleViewMixinTestCase(base.BaseTestCase):
         self.assertEqual(simple_view_model.str_property, "bar")
         self.assertIs(simple_view_model.none_property, None)
         self.assertIs(simple_view_model.uuid.__class__, uuid.UUID)
+
+
+class ModelBuiltWithoutInitTestCase(base.BaseTestCase):
+    """A model built with `__new__` writes into the class, not into itself.
+
+    Until `pour` runs, `self.properties` is the class's `PropertyCollection` —
+    the declaration every instance shares. Setting a property through it used
+    to succeed quietly and change that property for every live instance in the
+    process, which is a failure at a distance: the object that misbehaves is
+    not the one that was built wrong.
+    """
+
+    class Poured(models.Model):
+        first = properties.property(types.String(), default="")
+        second = properties.property(types.String(), default="")
+
+    def test_setting_a_property_before_pour_is_refused(self):
+        model = self.Poured.__new__(self.Poured)
+
+        self.assertRaises(
+            exceptions.PropertyClassAssignment, setattr, model, "first", "value"
+        )
+
+    def test_unrelated_models_are_left_alone(self):
+        """The write lands on the property *class*, which every model shares:
+        without the guard an assignment on one model changes what a different
+        model reads, including instances built afterwards."""
+
+        class Other(models.Model):
+            only = properties.property(types.String(), default="")
+
+        other = Other(only="other")
+
+        try:
+            setattr(self.Poured.__new__(self.Poured), "first", "poison")
+        except exceptions.PropertyClassAssignment:
+            pass
+
+        self.assertEqual(other.only, "other")
+        self.assertEqual(Other(only="later").only, "later")
+
+    def test_other_instances_are_left_alone(self):
+        one = self.Poured(first="one", second="1")
+        two = self.Poured(first="two", second="2")
+
+        try:
+            setattr(self.Poured.__new__(self.Poured), "first", "poison")
+        except exceptions.PropertyClassAssignment:
+            pass
+
+        self.assertEqual(one.first, "one")
+        self.assertEqual(two.first, "two")
+
+    def test_restore_still_builds_with_new_and_pours(self):
+        """`restore()` is the legitimate user of `__new__` and must keep
+        working: `pour` assigns `properties`, which is not a declared property
+        and so never reaches the guard."""
+        model = self.Poured.restore(first="restored", second="yes")
+
+        self.assertEqual(model.first, "restored")
+        self.assertEqual(model.second, "yes")
+
+    def test_a_poured_model_sets_properties_as_before(self):
+        model = self.Poured(first="a", second="b")
+
+        model.first = "changed"
+
+        self.assertEqual(model.first, "changed")
+        self.assertEqual(model.second, "b")
+
+    def test_a_plain_attribute_is_not_this_guard_s_business(self):
+        model = self.Poured.__new__(self.Poured)
+
+        model.not_a_property = 42
+
+        self.assertEqual(model.not_a_property, 42)


### PR DESCRIPTION
A model built with `Model.__new__(Model)` has no properties of its own: until `pour` runs, `self.properties` is still the class's collection, and what that yields for a name is the property *class* rather than an instance of it. So the assignment in `Model.__setattr__` lands on the class, where it shadows the `value` descriptor for every property of every model in the process:

    alpha, beta = Alpha(a="ALPHA"), Beta(b="BETA")   # unrelated models

    n = Alpha.__new__(Alpha)
    n.a = "POISON"                                   # one assignment

    alpha.a -> 'POISON'
    beta.b  -> 'POISON'                              # different model
    Beta(b="later").b -> 'POISON'                    # built afterwards

Nothing was raised, so the damage surfaced wherever somebody next read a model — a failure with no relation to the code that caused it, and easy to reach from test code, where building a model without invoking its constructor is a natural shortcut.

The check is on the property metaclass, so it costs nothing: it fires only on an assignment to a class object, and a property write on an instance never reaches it. `Model.__setattr__` is left exactly as it was — the first version of this put the check there and it cost ~260ns of ~1600 on every property write, about 17%.

`restore()` is the legitimate user of `__new__` and keeps working — `pour` assigns `properties`, which is not a declared property — and plain attributes are unaffected. Reads are left alone: the write is what escapes into shared state, and raising on reads would change what a half-built object looks like to `copy` and to anything that inspects models defensively.

Not a regression: identical on 15.0.12, 15.2.2, 15.2.8 and 15.3.0.